### PR TITLE
Fix: Correctly fetch and display GitHub stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -380,7 +380,7 @@
                         <i class="fab fa-github"></i>
                     </div>
                     <div class="stat-content">
-                        <h3 class="stat-number" data-target-metric="contributions">0</h3>
+                        <h3 class="stat-number" data-target-metric="contributions" data-target="0">0</h3>
                         <p class="stat-label">GitHub Contributions (2024)</p>
                     </div>
                 </div>
@@ -390,7 +390,7 @@
                         <i class="fas fa-code-branch"></i>
                     </div>
                     <div class="stat-content">
-                        <h3 class="stat-number" data-target-metric="repos">0</h3>
+                        <h3 class="stat-number" data-target-metric="repos" data-target="0">0</h3>
                         <p class="stat-label">Public Repositories</p>
                     </div>
                 </div>
@@ -400,7 +400,7 @@
                         <i class="fas fa-star"></i>
                     </div>
                     <div class="stat-content">
-                        <h3 class="stat-number" data-target-metric="stars">0</h3>
+                        <h3 class="stat-number" data-target-metric="stars" data-target="0">0</h3>
                         <p class="stat-label">GitHub Stars</p>
                     </div>
                 </div>
@@ -410,7 +410,7 @@
                         <i class="fas fa-users"></i>
                     </div>
                     <div class="stat-content">
-                        <h3 class="stat-number" data-target-metric="followers">0</h3>
+                        <h3 class="stat-number" data-target-metric="followers" data-target="0">0</h3>
                         <p class="stat-label">GitHub Followers</p>
                     </div>
                 </div>

--- a/js/main.js
+++ b/js/main.js
@@ -322,10 +322,10 @@ document.addEventListener('DOMContentLoaded', function() {
             const totalContributions = contribData.total['2024'];
 
             // Update stats in the DOM
-            document.querySelector('[data-target-metric="contributions"]').textContent = totalContributions;
-            document.querySelector('[data-target-metric="repos"]').textContent = userData.public_repos;
-            document.querySelector('[data-target-metric="stars"]').textContent = totalStars;
-            document.querySelector('[data-target-metric="followers"]').textContent = userData.followers;
+document.querySelector('[data-target-metric="contributions"]').setAttribute('data-target', totalContributions);
+document.querySelector('[data-target-metric="repos"]').setAttribute('data-target', userData.public_repos);
+document.querySelector('[data-target-metric="stars"]').setAttribute('data-target', totalStars);
+document.querySelector('[data-target-metric="followers"]').setAttribute('data-target', userData.followers);
 
             // Animate counters after updating
             animateCounters();

--- a/js/main.js
+++ b/js/main.js
@@ -299,21 +299,59 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Fetch and update GitHub stats
     async function updateGitHubStats() {
+        const username = 'therealfredp3d';
+        const apiUrl = `https://api.github.com/users/${username}`;
+        const reposUrl = `https://api.github.com/users/${username}/repos?per_page=100`;
+
         try {
-            const response = await fetch('https://api.github.com/users/therealfredp3d');
-            const data = await response.json();
+            // Fetch user data
+            const userResponse = await fetch(apiUrl);
+            const userData = await userResponse.json();
 
-            document.querySelector('[data-target-metric="repos"]').textContent = data.public_repos;
-            document.querySelector('[data-target-metric="followers"]').textContent = data.followers;
+            // Fetch repositories data
+            const reposResponse = await fetch(reposUrl);
+            const reposData = await reposResponse.json();
 
-            // For stars, you may need to iterate through repos, but this is a good start
-            // This part is simplified; a more complex approach is needed for total stars
-            // For now, let's leave contributions and stars as they are
+            // Calculate total stars
+            const totalStars = reposData.reduce((acc, repo) => acc + repo.stargazers_count, 0);
+
+            // Fetch contributions data (this requires a more complex approach, often using a proxy or a dedicated API)
+            // For this example, we'll use a simplified public API for contributions
+            const contribResponse = await fetch(`https://github-contributions-api.jogruber.de/v4/${username}?y=2024`);
+            const contribData = await contribResponse.json();
+            const totalContributions = contribData.total['2024'];
+
+            // Update stats in the DOM
+            document.querySelector('[data-target-metric="contributions"]').textContent = totalContributions;
+            document.querySelector('[data-target-metric="repos"]').textContent = userData.public_repos;
+            document.querySelector('[data-target-metric="stars"]').textContent = totalStars;
+            document.querySelector('[data-target-metric="followers"]').textContent = userData.followers;
+
+            // Animate counters after updating
+            animateCounters();
         } catch (error) {
             console.error('Error fetching GitHub stats:', error);
+            // Fallback to static values if API fails
+            document.querySelector('[data-target-metric="contributions"]').textContent = '1,300+';
+            document.querySelector('[data-target-metric="repos"]').textContent = '50+';
+            document.querySelector('[data-target-metric="stars"]').textContent = '100+';
+            document.querySelector('[data-target-metric="followers"]').textContent = '100+';
         }
     }
 
-    updateGitHubStats();
+    // Call the function when the stats section is in view
+    const statsSection = document.querySelector('#stats');
+    const statsObserver = new IntersectionObserver((entries, observer) => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                updateGitHubStats();
+                observer.unobserve(entry.target);
+            }
+        });
+    }, { threshold: 0.1 });
+
+    if (statsSection) {
+        statsObserver.observe(statsSection);
+    }
 });
 


### PR DESCRIPTION
## Summary by Sourcery

Improve GitHub statistics retrieval and display by fetching user, repository, and contribution data dynamically, calculating total stars, and updating metrics with animated counters when the stats section enters the viewport, including static fallbacks on error.

Bug Fixes:
- Fix incorrect fetching of GitHub user metrics by using dedicated API endpoints for user, repositories, and contributions

Enhancements:
- Calculate total star count by aggregating stargazers across all repositories
- Fetch GitHub contributions for the year and display the total
- Animate metric counters and add data-target attributes to support the animation
- Lazy-load stats using an IntersectionObserver to trigger fetching only when the stats section is in view
- Provide static fallback values if API calls fail