### PR TITLE
Add Detailed Projects Portfolio Section

### DIFF
--- a/.github/instructions/codacy.instructions.md
+++ b/.github/instructions/codacy.instructions.md
@@ -1,0 +1,72 @@
+---
+    description: Configuration for AI behavior when interacting with Codacy's MCP Server
+    applyTo: '**'
+---
+---
+# Codacy Rules
+Configuration for AI behavior when interacting with Codacy's MCP Server
+
+## CRITICAL: After ANY successful `edit_file` or `reapply` operation
+- YOU MUST IMMEDIATELY run the `codacy_cli_analyze` tool from Codacy's MCP Server for each file that was edited, with:
+ - `rootPath`: set to the workspace path
+ - `file`: set to the path of the edited file
+ - `tool`: leave empty or unset
+- If any issues are found in the new edits, propose and apply fixes for them.
+- > NOTE: Failure to follow this rule is considered a critical error.
+
+## When you tried to run the `codacy_cli_analyze` tool and the Codacy CLI is not installed
+- Ask the user 'Codacy CLI is not installed. Would you like me to install it now?'
+- If the user responds with "yes", run the `codacy_cli_install` tool and then continue with the original task
+- If the user responds with "no", instruct the user that they can disable automatic analysis in the extension settings
+- Wait for the user to respond before proceeding with any other actions
+
+## After every response
+- If you made any file edits in this conversation, verify you ran `codacy_cli_analyze` tool from Codacy's MCP Server 
+
+## When there are no Codacy MCP Server tools available, or the MCP Server is not reachable
+- Suggest the user the following troubleshooting steps:
+ - Try to reset the MCP on the extension
+ - If the user is using VSCode, suggest them to review their Copilot > MCP settings in Github, under their organization or personal account. Refer them to Settings > Copilot > Enable MCP servers in Copilot. Suggested URL (https://github.com/settings/copilot/features) or https://github.com/organizations/{organization-name}/settings/copilot/features (This can only be done by their organization admins / owners)
+- If none of the above steps work, suggest the user to contact Codacy support
+
+## Trying to call a tool that needs a rootPath as a parameter
+- Always use the standard, non-URL-encoded file system path
+
+## CRITICAL: Dependencies and Security Checks
+- IMMEDIATELY after ANY of these actions:
+ - Running npm/yarn/pnpm install
+ - Adding dependencies to package.json
+ - Adding requirements to requirements.txt
+ - Adding dependencies to pom.xml
+ - Adding dependencies to build.gradle
+ - Any other package manager operations
+- You MUST run the `codacy_cli_analyze` tool with:
+ - `rootPath`: set to the workspace path
+ - `tool`: set to "trivy"
+ - `file`: leave empty or unset
+- If any vulnerabilities are found because of the newly added packages:
+ - Stop all other operations
+ - Propose and apply fixes for the security issues
+ - Only continue with the original task after security issues are resolved
+- EXAMPLE:
+ - After: npm install react-markdown
+ - Do: Run codacy_cli_analyze with trivy
+ - Before: Continuing with any other tasks
+
+## General
+- Repeat the relevant steps for each modified file.
+- "Propose fixes" means to both suggest and, if possible, automatically apply the fixes.
+- You MUST NOT wait for the user to ask for analysis or remind you to run the tool.
+- Do not run `codacy_cli_analyze` looking for changes in duplicated code or code complexity metrics.
+- Complexity metrics are different from complexity issues. When trying to fix complexity in a repository or file, focus on solving the complexity issues and ignore the complexity metric.
+- Do not run `codacy_cli_analyze` looking for changes in code coverage.
+- Do not try to manually install Codacy CLI using either brew, npm, npx, or any other package manager.
+- If the Codacy CLI is not installed, just run the `codacy_cli_analyze` tool from Codacy's MCP Server.
+- When calling `codacy_cli_analyze`, only send provider, organization and repository if the project is a git repository.
+
+## Whenever a call to a Codacy tool that uses `repository` or `organization` as a parameter returns a 404 error
+- Offer to run the `codacy_setup_repository` tool to add the repository to Codacy
+- If the user accepts, run the `codacy_setup_repository` tool
+- Do not ever try to run the `codacy_setup_repository` tool on your own
+- After setup, immediately retry the action that failed (only retry once)
+---

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /.vscode/_DEV_NOTES_
+
+#Ignore vscode AI rules
+.github\instructions\codacy.instructions.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - 2026-06-07
 
 ### Security
+- **FIXED**: Eliminated remaining `innerHTML` template-string usage in `js/projects.js`
+  - `renderProjects()` now clears the container with a `while/removeChild` loop and
+    appends cards via `createProjectCard()` returning real DOM nodes
+  - `openModal()` fully rewritten using `createSafeElement`, `setSafeUrl`, and
+    `document.createTextNode` — no template literals injected into the DOM
+  - `formatMarkdown()` already returned a `DocumentFragment`; `openModal()` now
+    appends it directly instead of injecting it via `innerHTML`
+
+### Changed
+- **IMPROVED**: `onerror` fallback for project images moved from inline HTML attribute
+  into a dedicated `attachImageFallback(img)` JS helper
+  - Behaviour is now centralised; updating the fallback path requires changing
+    only the `FALLBACK_IMAGE` constant at the top of `js/projects.js`
+  - Applies consistently to both card images and modal hero images
+- **FIXED**: `data-tag="React"` filter button replaced with `data-tag="TypeScript"`
+  in `projects.html` — `React` matched no project tags so the filter always
+  returned empty results; `TypeScript` is present on two projects
+  - `"React"` tag updated to `"TypeScript"` in `QuickHubPulse` and
+    `PullRequest-Mermaid-Extractor` entries in `projectsData`
+  - `"Game"` filter added to replace the unused `"LLM"` button (matches
+    `Buzz-Bites`)
+- **IMPROVED**: Inline `<style>` block extracted from `projects.html` into new
+  `css/projects.css`
+  - All rules namespaced under `.projects-page` to avoid specificity conflicts
+    with global styles
+  - `<body>` tag in `projects.html` updated to `<body class="projects-page">`
+  - `<link rel="stylesheet" href="css/projects.css">` added to `<head>`
+- **IMPROVED**: Navbar in `projects.html` standardised to match `index.html` and
+  `blog-enhanced.html` (consistent link order, `index.html` home href, `<span
+  class="bar">` pattern)
+
+## [Unreleased] - 2026-06-07 (earlier)
+
+### Security
 - **FIXED**: Reverse-tabnabbing vulnerability in `js/projects.js`
   - `createSafeElement` now tracks when `target="_blank"` is set and **always** applies
     `rel="noopener noreferrer"` after the attribute loop, regardless of caller input
@@ -23,7 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Changed from movement-based fade to time-based fade with 1-second duration
   - Added timestamp tracking to trail points for accurate age calculation
   - Implemented continuous fade loop running at 60fps for smooth transitions
-  - Improved visual consistency and smoother trail behavior
+  - Improved visual consistency and smoother trail behaviour
 
 ## [Previous] - 2025-01-26
 
@@ -46,7 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed inconsistent tag filtering by aligning `data-tag` attribute with button label
   - Changed `data-tag="Orwell"` to `data-tag="Analysis"` in blog.html
-- Fixed unreliable date sorting by standardizing date format
+- Fixed unreliable date sorting by standardising date format
   - Converted all blog post dates from mixed formats to ISO format (YYYY-MM-DD)
   - Ensures consistent chronological ordering in `getRecentPosts()`
 
@@ -76,7 +110,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Technical Debt
 - Eliminated security anti-patterns (innerHTML usage with user data)
 - Removed performance bottlenecks (DOM recreation in animation loops)
-- Standardized data formats for reliable operations
+- Standardised data formats for reliable operations
 - Consolidated scattered initialization code
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2026-06-07
+
+### Security
+- **FIXED**: Reverse-tabnabbing vulnerability in `js/projects.js`
+  - `createSafeElement` now tracks when `target="_blank"` is set and **always** applies
+    `rel="noopener noreferrer"` after the attribute loop, regardless of caller input
+  - This covers both the card GitHub icon link and the modal "View Repository" button
+  - Added `rel` to `SAFE_ATTRS` allowlist so callers can also pass it explicitly if needed
+  - Discards any `target` value other than `_blank` to prevent `_parent`/`_top` abuse
+  - Matches the safer pattern already used elsewhere in the codebase (e.g. `blog-enhanced.html`)
+
 ## [Unreleased] - 2025-01-26
 
 ### Enhanced
-
 - **IMPROVED**: Modified cursor trailing effect to fade over time instead of on mouse movement
   - Changed from movement-based fade to time-based fade with 1-second duration
   - Added timestamp tracking to trail points for accurate age calculation
@@ -18,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Previous] - 2025-01-26
 
 ### Security
-
 - **CRITICAL**: Fixed XSS vulnerabilities by replacing all `innerHTML` usage with safe DOM methods
   - Replaced `featuredContainer.innerHTML` with secure DOM creation in `loadFeaturedPosts()`
   - Replaced `postsContainer.innerHTML` with secure DOM creation in `loadAllPosts()`
@@ -27,7 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Implemented proper input sanitization for email addresses
 
 ### Performance
-
 - **MAJOR**: Optimized mouse trail animation for better performance
   - Implemented element pooling strategy to eliminate DOM recreation on every mousemove
   - Pre-creates fixed pool of 20 trail elements on initialization
@@ -36,7 +44,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Prevents flickering and improves animation smoothness
 
 ### Fixed
-
 - Fixed inconsistent tag filtering by aligning `data-tag` attribute with button label
   - Changed `data-tag="Orwell"` to `data-tag="Analysis"` in blog.html
 - Fixed unreliable date sorting by standardizing date format
@@ -44,7 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Ensures consistent chronological ordering in `getRecentPosts()`
 
 ### Changed
-
 - **MAJOR**: Refactored blog.js for better security and maintainability
   - Extracted `renderPost()` helper function to eliminate code duplication
   - Consolidated multiple `DOMContentLoaded` listeners into single `initBlog()` function
@@ -54,7 +60,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Implemented `updateActiveFilter()` for cleaner filter state management
 
 ### Added
-
 - Added comprehensive URL validation in DOM creation helpers
 - Added email validation with proper regex pattern matching
 - Added safe DOM manipulation utilities to prevent XSS attacks
@@ -62,7 +67,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added centralized style injection for notifications
 
 ### Improved
-
 - Enhanced code organization with clear separation of concerns
 - Improved error handling and input validation
 - Better performance monitoring capabilities
@@ -70,7 +74,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Consistent code style and naming conventions
 
 ### Technical Debt
-
 - Eliminated security anti-patterns (innerHTML usage with user data)
 - Removed performance bottlenecks (DOM recreation in animation loops)
 - Standardized data formats for reliable operations
@@ -93,23 +96,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Notes
 
 ### Breaking Changes
-
 - Blog post date format changed from mixed formats to ISO format (YYYY-MM-DD)
 - Some internal function signatures changed due to security refactoring
 - Global namespace pollution reduced through IIFE encapsulation
 
 ### Migration Guide
-
 - No user-facing changes required
 - All functionality preserved with improved security and performance
 - Existing blog data automatically uses new date format
 
 ### Security Advisory
-
 This release addresses critical XSS vulnerabilities. Users are strongly advised to update immediately.
 
 ### Performance Impact
-
 - Mouse trail animations now run significantly smoother
 - Reduced memory allocation and garbage collection pressure
 - Eliminated DOM query overhead in animation loops

--- a/blog-enhanced.html
+++ b/blog-enhanced.html
@@ -156,13 +156,13 @@
                 <a href="index.html" class="logo-text">THEREALFRED.CA</a>
             </div>
             <ul class="nav-menu">
-                <li><a href="index.html" class="nav-link">Home</a></li>
-                <li><a href="index.html#about" class="nav-link">About</a></li>
-                <li><a href="index.html#skills" class="nav-link">Skills</a></li>
-                <li><a href="index.html#projects" class="nav-link">Projects</a></li>
-                <li><a href="index.html#stats" class="nav-link">Stats</a></li>
+                <li><a href="index.html" class="nav-link ">Home</a></li>
+                <li><a href="index.html#about" class="nav-link ">About</a></li>
+                <li><a href="index.html#skills" class="nav-link ">Skills</a></li>
+                <li><a href="projects.html" class="nav-link ">Projects</a></li>
                 <li><a href="blog-enhanced.html" class="nav-link active">Blog</a></li>
-                <li><a href="index.html#contact" class="nav-link">Contact</a></li>
+                <li><a href="index.html#stats" class="nav-link ">Stats</a></li>
+                <li><a href="index.html#contact" class="nav-link ">Contact</a></li>
             </ul>
             <div class="hamburger">
                 <span></span>
@@ -297,7 +297,7 @@
                         <li><a href="index.html">Home</a></li>
                         <li><a href="index.html#about">About</a></li>
                         <li><a href="index.html#skills">Skills</a></li>
-                        <li><a href="index.html#projects">Projects</a></li>
+                        <li><a href="projects.html">Projects</a></li>
                         <li><a href="blog-enhanced.html">Blog</a></li>
                         <li><a href="index.html#contact">Contact</a></li>
                     </ul>

--- a/blog-enhanced.html
+++ b/blog-enhanced.html
@@ -156,13 +156,13 @@
                 <a href="index.html" class="logo-text">THEREALFRED.CA</a>
             </div>
             <ul class="nav-menu">
-                <li><a href="index.html" class="nav-link ">Home</a></li>
-                <li><a href="index.html#about" class="nav-link ">About</a></li>
-                <li><a href="index.html#skills" class="nav-link ">Skills</a></li>
-                <li><a href="projects.html" class="nav-link ">Projects</a></li>
+                <li><a href="index.html" class="nav-link">Home</a></li>
+                <li><a href="index.html#about" class="nav-link">About</a></li>
+                <li><a href="index.html#skills" class="nav-link">Skills</a></li>
+                <li><a href="projects.html" class="nav-link">Projects</a></li>
                 <li><a href="blog-enhanced.html" class="nav-link active">Blog</a></li>
-                <li><a href="index.html#stats" class="nav-link ">Stats</a></li>
-                <li><a href="index.html#contact" class="nav-link ">Contact</a></li>
+                <li><a href="index.html#stats" class="nav-link">Stats</a></li>
+                <li><a href="index.html#contact" class="nav-link">Contact</a></li>
             </ul>
             <div class="hamburger">
                 <span></span>

--- a/css/projects.css
+++ b/css/projects.css
@@ -1,0 +1,300 @@
+/* Projects Page Styles - extracted from projects.html inline <style> block */
+
+.projects-page {
+    background-color: var(--bg-color, #0a192f);
+    color: var(--text-primary, #ccd6f6);
+}
+
+.projects-page .projects-header {
+    padding: 8rem 0 4rem;
+    text-align: center;
+    background: linear-gradient(to bottom, rgba(0, 255, 0, 0.05), transparent);
+}
+
+.projects-page .projects-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 2rem;
+    margin-top: 3rem;
+}
+
+.projects-page .project-card {
+    background: var(--card-bg, rgba(17, 34, 64, 0.7));
+    border-radius: 12px;
+    overflow: hidden;
+    border: 1px solid rgba(0, 255, 0, 0.1);
+    transition: all 0.3s ease;
+    display: flex;
+    flex-direction: column;
+}
+
+.projects-page .project-card:hover {
+    transform: translateY(-10px);
+    border-color: var(--accent-color, #00ff00);
+    box-shadow: 0 10px 30px -15px rgba(0, 255, 0, 0.3);
+}
+
+.projects-page .project-image {
+    height: 200px;
+    position: relative;
+    overflow: hidden;
+}
+
+.projects-page .project-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    opacity: 0.8;
+    transition: transform 0.5s ease;
+}
+
+.projects-page .project-card:hover .project-image img {
+    transform: scale(1.1);
+    opacity: 1;
+}
+
+.projects-page .project-stats-overlay {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    background: rgba(10, 25, 47, 0.8);
+    padding: 0.5rem 1rem;
+    border-top-left-radius: 12px;
+    display: flex;
+    gap: 1rem;
+    font-size: 0.8rem;
+    color: var(--accent-color, #00ff00);
+}
+
+.projects-page .project-content {
+    padding: 1.5rem;
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.projects-page .project-title {
+    color: var(--accent-color, #00ff00);
+    margin-bottom: 1rem;
+    font-size: 1.25rem;
+}
+
+.projects-page .project-description {
+    color: var(--text-secondary, #8892b0);
+    font-size: 0.9rem;
+    line-height: 1.6;
+    margin-bottom: 1.5rem;
+}
+
+.projects-page .project-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.projects-page .tag-badge {
+    background: rgba(0, 255, 0, 0.1);
+    color: var(--accent-color, #00ff00);
+    padding: 0.2rem 0.8rem;
+    border-radius: 20px;
+    font-size: 0.75rem;
+    border: 1px solid rgba(0, 255, 0, 0.2);
+}
+
+.projects-page .project-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: auto;
+}
+
+.projects-page .github-link {
+    color: var(--text-secondary, #8892b0);
+    font-size: 1.5rem;
+    transition: color 0.3s;
+}
+
+.projects-page .github-link:hover {
+    color: var(--accent-color, #00ff00);
+}
+
+/* Search and Filter */
+.projects-page .controls-section {
+    margin-bottom: 3rem;
+}
+
+.projects-page .search-wrapper {
+    max-width: 600px;
+    margin: 0 auto 2rem;
+    position: relative;
+}
+
+.projects-page .search-wrapper i {
+    position: absolute;
+    left: 1.5rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--text-secondary, #8892b0);
+}
+
+.projects-page .search-input {
+    width: 100%;
+    background: var(--card-bg, rgba(17, 34, 64, 0.7));
+    border: 1px solid rgba(0, 255, 0, 0.1);
+    padding: 1rem 1rem 1rem 3.5rem;
+    border-radius: 30px;
+    color: var(--text-primary, #ccd6f6);
+    outline: none;
+    transition: border-color 0.3s;
+    font-family: inherit;
+    font-size: 1rem;
+}
+
+.projects-page .search-input:focus {
+    border-color: var(--accent-color, #00ff00);
+}
+
+.projects-page .filter-tags {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.projects-page .tag-filter {
+    background: transparent;
+    border: 1px solid rgba(0, 255, 0, 0.2);
+    color: var(--text-secondary, #8892b0);
+    padding: 0.5rem 1.5rem;
+    border-radius: 20px;
+    cursor: pointer;
+    transition: all 0.3s;
+    font-family: inherit;
+    font-size: 0.9rem;
+}
+
+.projects-page .tag-filter.active,
+.projects-page .tag-filter:hover {
+    background: var(--accent-color, #00ff00);
+    color: var(--bg-color, #0a192f);
+    border-color: var(--accent-color, #00ff00);
+}
+
+/* Modal */
+.projects-page .modal {
+    display: none;
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(10, 25, 47, 0.95);
+    backdrop-filter: blur(5px);
+    overflow-y: auto;
+}
+
+.projects-page .modal-content {
+    background-color: var(--card-bg, rgba(17, 34, 64, 0.7));
+    margin: 5% auto;
+    padding: 0;
+    border: 1px solid rgba(0, 255, 0, 0.2);
+    width: 90%;
+    max-width: 900px;
+    border-radius: 15px;
+    position: relative;
+    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.5);
+}
+
+.projects-page .close-modal {
+    position: absolute;
+    right: 20px;
+    top: 20px;
+    color: var(--text-secondary, #8892b0);
+    font-size: 28px;
+    font-weight: bold;
+    cursor: pointer;
+    z-index: 10;
+    transition: color 0.3s;
+    background: none;
+    border: none;
+    line-height: 1;
+}
+
+.projects-page .close-modal:hover {
+    color: var(--accent-color, #00ff00);
+}
+
+.projects-page .modal-header {
+    position: relative;
+    padding: 3rem 2rem 2rem;
+    text-align: center;
+}
+
+.projects-page .modal-hero-image {
+    width: 100%;
+    height: 300px;
+    object-fit: cover;
+    border-radius: 10px;
+    margin-bottom: 2rem;
+    border: 1px solid rgba(0, 255, 0, 0.1);
+}
+
+.projects-page .modal-meta {
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+    color: var(--text-secondary, #8892b0);
+    font-size: 0.9rem;
+    margin-top: 1rem;
+}
+
+.projects-page .modal-body {
+    padding: 0 3rem 3rem;
+    line-height: 1.8;
+    color: var(--text-primary, #ccd6f6);
+}
+
+.projects-page .modal-body h2,
+.projects-page .modal-body h3 {
+    color: var(--accent-color, #00ff00);
+    margin: 2rem 0 1rem;
+}
+
+.projects-page .modal-footer {
+    padding: 2rem 3rem;
+    border-top: 1px solid rgba(0, 255, 0, 0.1);
+    text-align: center;
+}
+
+/* Empty state */
+.projects-page .empty-state {
+    text-align: center;
+    grid-column: 1 / -1;
+    padding: 4rem;
+}
+
+.projects-page .empty-state i {
+    font-size: 4rem;
+    color: var(--accent-color, #00ff00);
+    opacity: 0.3;
+    margin-bottom: 1rem;
+    display: block;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .projects-page .modal-body {
+        padding: 0 1.5rem 2rem;
+    }
+
+    .projects-page .modal-footer {
+        padding: 1.5rem;
+    }
+
+    .projects-page .modal-meta {
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -30,12 +30,12 @@
             </div>
             <ul class="nav-menu">
                 <li><a href="index.html" class="nav-link active">Home</a></li>
-                <li><a href="index.html#about" class="nav-link ">About</a></li>
-                <li><a href="index.html#skills" class="nav-link ">Skills</a></li>
-                <li><a href="projects.html" class="nav-link ">Projects</a></li>
-                <li><a href="blog-enhanced.html" class="nav-link ">Blog</a></li>
-                <li><a href="index.html#stats" class="nav-link ">Stats</a></li>
-                <li><a href="index.html#contact" class="nav-link ">Contact</a></li>
+                <li><a href="index.html#about" class="nav-link">About</a></li>
+                <li><a href="index.html#skills" class="nav-link">Skills</a></li>
+                <li><a href="projects.html" class="nav-link">Projects</a></li>
+                <li><a href="blog-enhanced.html" class="nav-link">Blog</a></li>
+                <li><a href="index.html#stats" class="nav-link">Stats</a></li>
+                <li><a href="index.html#contact" class="nav-link">Contact</a></li>
             </ul>
             <div class="hamburger">
                 <span class="bar"></span>

--- a/index.html
+++ b/index.html
@@ -26,16 +26,16 @@
     <nav class="navbar">
         <div class="nav-container">
             <div class="nav-logo">
-                <a href="#" class="logo-text">THEREALFRED.CA</a>
+                <a href="index.html#" class="logo-text">THEREALFRED.CA</a>
             </div>
             <ul class="nav-menu">
-                <li><a href="#home" class="nav-link">Home</a></li>
-                <li><a href="#about" class="nav-link">About</a></li>
-                <li><a href="#skills" class="nav-link">Skills</a></li>
-                <li><a href="#projects" class="nav-link">Projects</a></li>
-                <li><a href="#stats" class="nav-link">Stats</a></li>
-                <li><a href="blog.html" class="nav-link">Blog</a></li>
-                <li><a href="#contact" class="nav-link">Contact</a></li>
+                <li><a href="index.html" class="nav-link active">Home</a></li>
+                <li><a href="index.html#about" class="nav-link ">About</a></li>
+                <li><a href="index.html#skills" class="nav-link ">Skills</a></li>
+                <li><a href="projects.html" class="nav-link ">Projects</a></li>
+                <li><a href="blog-enhanced.html" class="nav-link ">Blog</a></li>
+                <li><a href="index.html#stats" class="nav-link ">Stats</a></li>
+                <li><a href="index.html#contact" class="nav-link ">Contact</a></li>
             </ul>
             <div class="hamburger">
                 <span class="bar"></span>
@@ -63,8 +63,8 @@
                     <span class="highlight">software development</span>
                 </p>
                 <div class="hero-buttons">
-                    <a href="#projects" class="btn btn-primary">View Projects</a>
-                    <a href="#contact" class="btn btn-secondary">Contact Me</a>
+                    <a href="projects.html" class="btn btn-primary">View Projects</a>
+                    <a href="index.html#contact" class="btn btn-secondary">Contact Me</a>
                 </div>
             </div>
             <div class="hero-image">

--- a/js/projects.js
+++ b/js/projects.js
@@ -1,3 +1,79 @@
+// Allowed URL schemes for security validation
+const ALLOWED_URL_SCHEMES = ['https:', 'http:'];
+
+/**
+ * Safely sets an href or src attribute after validating the URL.
+ * Blocks javascript: and other dangerous schemes.
+ * @param {HTMLElement} el - Element to set attribute on
+ * @param {string} attr - Attribute name ('href' or 'src')
+ * @param {string} value - URL value to validate and set
+ * @param {string[]} [allowedSchemes] - Allowed URL schemes
+ */
+function setSafeUrl(el, attr, value, allowedSchemes = ALLOWED_URL_SCHEMES) {
+    if (!value || typeof value !== 'string') {
+        console.warn(`setSafeUrl: empty or non-string value for ${attr}`);
+        return;
+    }
+    try {
+        const parsed = new URL(value, window.location.href);
+        if (!allowedSchemes.includes(parsed.protocol)) {
+            console.warn(`setSafeUrl: blocked disallowed scheme "${parsed.protocol}" for ${attr}:`, value);
+            return;
+        }
+        el.setAttribute(attr, parsed.href);
+    } catch {
+        console.warn(`setSafeUrl: invalid URL blocked for ${attr}:`, value);
+    }
+}
+
+/**
+ * Creates a DOM element with optional class, text content, and safe attributes.
+ * Validates href/src attributes to prevent XSS via javascript: URLs.
+ * When target="_blank" is set, rel="noopener noreferrer" is always applied
+ * to prevent reverse-tabnabbing attacks via window.opener.
+ * @param {string} tag
+ * @param {string} [text]
+ * @param {string} [className]
+ * @param {Object} [attributes]
+ * @returns {HTMLElement}
+ */
+function createSafeElement(tag, text = '', className = '', attributes = {}) {
+    const el = document.createElement(tag);
+    if (className) el.className = className;
+    if (text) el.textContent = text;
+
+    // Track whether target="_blank" is being set so we can enforce rel
+    let hasBlankTarget = false;
+
+    for (const [key, value] of Object.entries(attributes)) {
+        if (key === 'href' || key === 'src') {
+            setSafeUrl(el, key, value);
+        } else if (key === 'target') {
+            if (value === '_blank') {
+                el.setAttribute('target', '_blank');
+                hasBlankTarget = true;
+            }
+            // Discard any other target value (e.g. _parent, _top) for safety
+        } else {
+            // Only allow safe, known attributes
+            const SAFE_ATTRS = new Set([
+                'alt', 'class', 'id', 'type', 'placeholder',
+                'data-id', 'data-tag', 'title', 'rel'
+            ]);
+            if (SAFE_ATTRS.has(key)) {
+                el.setAttribute(key, value);
+            }
+        }
+    }
+
+    // Always enforce rel="noopener noreferrer" on blank-target links,
+    // regardless of whether the caller supplied a rel attribute.
+    if (hasBlankTarget) {
+        el.setAttribute('rel', 'noopener noreferrer');
+    }
+
+    return el;
+}
 
 const projectsData = [
     {
@@ -145,27 +221,16 @@ class ProjectManager {
         const container = document.getElementById('projects-grid');
         if (!container) return;
 
-        // Clear container
+        // Clear container safely
         while (container.firstChild) {
             container.removeChild(container.firstChild);
         }
 
         if (this.filteredProjects.length === 0) {
-            const emptyState = document.createElement('div');
-            emptyState.className = 'empty-state';
-
-            const icon = document.createElement('i');
-            icon.className = 'fas fa-search';
-
-            const h3 = document.createElement('h3');
-            h3.textContent = 'No projects found';
-
-            const p = document.createElement('p');
-            p.textContent = 'Try adjusting your search or filters.';
-
-            emptyState.appendChild(icon);
-            emptyState.appendChild(h3);
-            emptyState.appendChild(p);
+            const emptyState = createSafeElement('div', '', 'empty-state');
+            emptyState.appendChild(createSafeElement('i', '', 'fas fa-search'));
+            emptyState.appendChild(createSafeElement('h3', 'No projects found'));
+            emptyState.appendChild(createSafeElement('p', 'Try adjusting your search or filters.'));
             container.appendChild(emptyState);
             return;
         }
@@ -179,85 +244,62 @@ class ProjectManager {
     }
 
     createProjectCard(project) {
-        const card = document.createElement('div');
-        card.className = 'project-card';
+        const card = createSafeElement('div', '', 'project-card');
         card.dataset.id = project.id;
 
-        const imageContainer = document.createElement('div');
-        imageContainer.className = 'project-image';
+        // Image container
+        const imageContainer = createSafeElement('div', '', 'project-image');
 
-        const img = document.createElement('img');
-        img.src = project.image;
-        img.alt = project.title;
-        img.onerror = () => { img.src = 'assets/images/python-background.jpg'; };
+        const img = createSafeElement('img', '', '', { alt: project.title || '' });
+        // Use setSafeUrl for image src; fall back to a safe local asset on error
+        setSafeUrl(img, 'src', project.image || '');
+        img.onerror = () => { img.setAttribute('src', 'assets/images/python-background.jpg'); };
 
-        const overlay = document.createElement('div');
-        overlay.className = 'project-stats-overlay';
+        const overlay = createSafeElement('div', '', 'project-stats-overlay');
 
-        const starSpan = document.createElement('span');
-        const starIcon = document.createElement('i');
-        starIcon.className = 'fas fa-star';
-        starSpan.appendChild(starIcon);
-        starSpan.appendChild(document.createTextNode(` ${project.stars}`));
+        const starSpan = createSafeElement('span');
+        starSpan.appendChild(createSafeElement('i', '', 'fas fa-star'));
+        starSpan.appendChild(document.createTextNode(` ${Number.isFinite(project.stars) ? project.stars : 0}`));
 
-        const forkSpan = document.createElement('span');
-        const forkIcon = document.createElement('i');
-        forkIcon.className = 'fas fa-code-branch';
-        forkSpan.appendChild(forkIcon);
-        forkSpan.appendChild(document.createTextNode(` ${project.forks}`));
+        const forkSpan = createSafeElement('span');
+        forkSpan.appendChild(createSafeElement('i', '', 'fas fa-code-branch'));
+        forkSpan.appendChild(document.createTextNode(` ${Number.isFinite(project.forks) ? project.forks : 0}`));
 
         overlay.appendChild(starSpan);
         overlay.appendChild(forkSpan);
         imageContainer.appendChild(img);
         imageContainer.appendChild(overlay);
 
-        const content = document.createElement('div');
-        content.className = 'project-content';
+        // Content
+        const content = createSafeElement('div', '', 'project-content');
+        content.appendChild(createSafeElement('h3', project.title || 'Untitled', 'project-title'));
+        content.appendChild(createSafeElement('p', project.description || '', 'project-description'));
 
-        const h3 = document.createElement('h3');
-        h3.className = 'project-title';
-        h3.textContent = project.title;
-
-        const p = document.createElement('p');
-        p.className = 'project-description';
-        p.textContent = project.description;
-
-        const tagsContainer = document.createElement('div');
-        tagsContainer.className = 'project-tags';
-        project.tags.forEach(tag => {
-            const span = document.createElement('span');
-            span.className = 'tag-badge';
-            span.textContent = tag;
-            tagsContainer.appendChild(span);
+        const tagsContainer = createSafeElement('div', '', 'project-tags');
+        (project.tags || []).forEach(tag => {
+            tagsContainer.appendChild(createSafeElement('span', String(tag), 'tag-badge'));
         });
+        content.appendChild(tagsContainer);
 
-        const footer = document.createElement('div');
-        footer.className = 'project-footer';
+        // Footer
+        const footer = createSafeElement('div', '', 'project-footer');
 
-        const btn = document.createElement('button');
-        btn.className = 'btn btn-primary view-details';
+        const btn = createSafeElement('button', 'View Details', 'btn btn-primary view-details');
         btn.dataset.id = project.id;
-        btn.textContent = 'View Details';
 
-        const githubLink = document.createElement('a');
-        githubLink.href = project.url;
-        githubLink.target = '_blank';
-        githubLink.className = 'github-link';
-        const githubIcon = document.createElement('i');
-        githubIcon.className = 'fab fa-github';
-        githubLink.appendChild(githubIcon);
+        // target="_blank" triggers automatic rel="noopener noreferrer" in createSafeElement
+        const githubLink = createSafeElement('a', '', 'github-link', {
+            href: project.url || '',
+            target: '_blank'
+        });
+        githubLink.appendChild(createSafeElement('i', '', 'fab fa-github'));
 
         footer.appendChild(btn);
         footer.appendChild(githubLink);
-
-        content.appendChild(h3);
-        content.appendChild(p);
-        content.appendChild(tagsContainer);
         content.appendChild(footer);
 
         card.appendChild(imageContainer);
         card.appendChild(content);
-
         return card;
     }
 
@@ -290,13 +332,12 @@ class ProjectManager {
         const modal = document.getElementById('project-modal');
         if (modal) {
             window.addEventListener('click', (event) => {
-                if (event.target == modal) {
+                if (event.target === modal) {
                     modal.style.display = 'none';
                     document.body.style.overflow = 'auto';
                 }
             });
 
-            // ESC key to close
             window.addEventListener('keydown', (e) => {
                 if (e.key === 'Escape' && modal.style.display === 'block') {
                     modal.style.display = 'none';
@@ -309,11 +350,14 @@ class ProjectManager {
     applyFilters() {
         this.filteredProjects = this.projects.filter(p => {
             const searchLower = this.searchQuery.toLowerCase();
-            const matchesSearch = p.title.toLowerCase().includes(searchLower) ||
-                                 p.description.toLowerCase().includes(searchLower);
+            const matchesSearch =
+                (p.title || '').toLowerCase().includes(searchLower) ||
+                (p.description || '').toLowerCase().includes(searchLower);
 
-            const matchesTag = this.currentFilter === 'all' ||
-                             p.tags.some(tag => tag.toLowerCase() === this.currentFilter.toLowerCase());
+            const matchesTag =
+                this.currentFilter === 'all' ||
+                (p.tags || []).some(tag => tag.toLowerCase() === this.currentFilter.toLowerCase());
+
             return matchesSearch && matchesTag;
         });
         this.renderProjects();
@@ -325,75 +369,61 @@ class ProjectManager {
 
         const modal = document.getElementById('project-modal');
         const content = document.getElementById('modal-project-content');
+        if (!modal || !content) return;
 
-        // Clear content
+        // Clear content safely
         while (content.firstChild) {
             content.removeChild(content.firstChild);
         }
 
-        const header = document.createElement('div');
-        header.className = 'modal-header';
+        // Header
+        const header = createSafeElement('div', '', 'modal-header');
 
-        const img = document.createElement('img');
-        img.src = project.image;
-        img.alt = project.title;
-        img.className = 'modal-hero-image';
-        img.onerror = () => { img.src = 'assets/images/python-background.jpg'; };
+        const img = createSafeElement('img', '', 'modal-hero-image', { alt: project.title || '' });
+        setSafeUrl(img, 'src', project.image || '');
+        img.onerror = () => { img.setAttribute('src', 'assets/images/python-background.jpg'); };
+        header.appendChild(img);
 
-        const h2 = document.createElement('h2');
-        h2.textContent = project.title;
+        header.appendChild(createSafeElement('h2', project.title || 'Untitled'));
 
-        const meta = document.createElement('div');
-        meta.className = 'modal-meta';
+        const meta = createSafeElement('div', '', 'modal-meta');
 
-        const stars = document.createElement('span');
-        const starIcon = document.createElement('i');
-        starIcon.className = 'fas fa-star';
-        stars.appendChild(starIcon);
-        stars.appendChild(document.createTextNode(` ${project.stars} Stars`));
+        const stars = createSafeElement('span');
+        stars.appendChild(createSafeElement('i', '', 'fas fa-star'));
+        stars.appendChild(document.createTextNode(` ${Number.isFinite(project.stars) ? project.stars : 0} Stars`));
 
-        const forks = document.createElement('span');
-        const forkIcon = document.createElement('i');
-        forkIcon.className = 'fas fa-code-branch';
-        forks.appendChild(forkIcon);
-        forks.appendChild(document.createTextNode(` ${project.forks} Forks`));
+        const forks = createSafeElement('span');
+        forks.appendChild(createSafeElement('i', '', 'fas fa-code-branch'));
+        forks.appendChild(document.createTextNode(` ${Number.isFinite(project.forks) ? project.forks : 0} Forks`));
 
-        const updated = document.createElement('span');
-        const clockIcon = document.createElement('i');
-        clockIcon.className = 'fas fa-clock';
-        updated.appendChild(clockIcon);
-        const dateStr = new Date(project.pushed_at).toLocaleDateString();
+        const updated = createSafeElement('span');
+        updated.appendChild(createSafeElement('i', '', 'fas fa-clock'));
+        let dateStr = 'Unknown';
+        try {
+            dateStr = new Date(project.pushed_at).toLocaleDateString();
+        } catch { /* keep default */ }
         updated.appendChild(document.createTextNode(` Last updated: ${dateStr}`));
 
         meta.appendChild(stars);
         meta.appendChild(forks);
         meta.appendChild(updated);
-
-        header.appendChild(img);
-        header.appendChild(h2);
         header.appendChild(meta);
 
-        const body = document.createElement('div');
-        body.className = 'modal-body';
-
-        const narrativeDiv = document.createElement('div');
-        narrativeDiv.className = 'narrative';
-        narrativeDiv.appendChild(this.formatMarkdown(project.narrative));
-
+        // Body — narrative rendered via safe DOM builder
+        const body = createSafeElement('div', '', 'modal-body');
+        const narrativeDiv = createSafeElement('div', '', 'narrative');
+        // Guard against null/undefined narrative
+        narrativeDiv.appendChild(this.formatMarkdown(project.narrative || ''));
         body.appendChild(narrativeDiv);
 
-        const footer = document.createElement('div');
-        footer.className = 'modal-footer';
-
-        const link = document.createElement('a');
-        link.href = project.url;
-        link.target = '_blank';
-        link.className = 'btn btn-primary';
-        const githubIcon = document.createElement('i');
-        githubIcon.className = 'fab fa-github';
-        link.appendChild(githubIcon);
+        // Footer — target="_blank" triggers automatic rel="noopener noreferrer"
+        const footer = createSafeElement('div', '', 'modal-footer');
+        const link = createSafeElement('a', '', 'btn btn-primary', {
+            href: project.url || '',
+            target: '_blank'
+        });
+        link.appendChild(createSafeElement('i', '', 'fab fa-github'));
         link.appendChild(document.createTextNode(' View Repository'));
-
         footer.appendChild(link);
 
         content.appendChild(header);
@@ -405,15 +435,24 @@ class ProjectManager {
 
         const closeBtn = modal.querySelector('.close-modal');
         if (closeBtn) {
-            closeBtn.onclick = () => {
+            // Clone to remove any stale listeners before re-attaching
+            const newClose = closeBtn.cloneNode(true);
+            closeBtn.parentNode.replaceChild(newClose, closeBtn);
+            newClose.onclick = () => {
                 modal.style.display = 'none';
                 document.body.style.overflow = 'auto';
             };
         }
     }
 
+    /**
+     * Converts a limited markdown subset (###/##/#, **bold**, bullet lists, plain paragraphs)
+     * into safe DOM nodes. No innerHTML is used at any point.
+     * @param {string} text
+     * @returns {DocumentFragment}
+     */
     formatMarkdown(text) {
-        const lines = text.split('\n');
+        const lines = (text || '').split('\n');
         const fragment = document.createDocumentFragment();
         let currentList = null;
 
@@ -429,6 +468,7 @@ class ProjectManager {
                 this.appendInline(li, trimmed.substring(2));
                 currentList.appendChild(li);
             } else {
+                // Any non-list line closes the current list
                 currentList = null;
 
                 if (trimmed.startsWith('### ')) {
@@ -454,8 +494,14 @@ class ProjectManager {
         return fragment;
     }
 
+    /**
+     * Appends inline text with **bold** support to a parent element.
+     * Uses textContent exclusively — no innerHTML.
+     * @param {HTMLElement} el
+     * @param {string} text
+     */
     appendInline(el, text) {
-        const parts = text.split(/(\*\*.+?\*\*)/g);
+        const parts = (text || '').split(/(\*\*.+?\*\*)/g);
         parts.forEach(part => {
             if (part.startsWith('**') && part.endsWith('**')) {
                 const strong = document.createElement('strong');

--- a/js/projects.js
+++ b/js/projects.js
@@ -133,6 +133,16 @@ class ProjectManager {
         this.updateStats();
     }
 
+    escapeHTML(str) {
+        if (!str) return '';
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#039;');
+    }
+
     renderProjects() {
         const container = document.getElementById('projects-grid');
         if (!container) return;
@@ -153,26 +163,30 @@ class ProjectManager {
     }
 
     createProjectCard(project) {
-        const tags = project.tags.map(tag => `<span class="tag-badge">${tag}</span>`).join('');
+        const tags = project.tags.map(tag => `<span class="tag-badge">${this.escapeHTML(tag)}</span>`).join('');
+        const title = this.escapeHTML(project.title);
+        const description = this.escapeHTML(project.description);
+        const image = this.escapeHTML(project.image);
+        const url = this.escapeHTML(project.url);
 
         return `
             <div class="project-card" data-id="${project.id}">
                 <div class="project-image">
-                    <img src="${project.image}" alt="${project.title}" onerror="this.src='assets/images/python-background.jpg'">
+                    <img src="${image}" alt="${title}" onerror="this.src='assets/images/python-background.jpg'">
                     <div class="project-stats-overlay">
                         <span><i class="fas fa-star"></i> ${project.stars}</span>
                         <span><i class="fas fa-code-branch"></i> ${project.forks}</span>
                     </div>
                 </div>
                 <div class="project-content">
-                    <h3 class="project-title">${project.title}</h3>
-                    <p class="project-description">${project.description}</p>
+                    <h3 class="project-title">${title}</h3>
+                    <p class="project-description">${description}</p>
                     <div class="project-tags">
                         ${tags}
                     </div>
                     <div class="project-footer">
                         <button class="btn btn-primary view-details" data-id="${project.id}">View Details</button>
-                        <a href="${project.url}" target="_blank" class="github-link"><i class="fab fa-github"></i></a>
+                        <a href="${url}" target="_blank" class="github-link"><i class="fab fa-github"></i></a>
                     </div>
                 </div>
             </div>
@@ -244,10 +258,14 @@ class ProjectManager {
         const modal = document.getElementById('project-modal');
         const content = document.getElementById('modal-project-content');
 
+        const title = this.escapeHTML(project.title);
+        const image = this.escapeHTML(project.image);
+        const url = this.escapeHTML(project.url);
+
         content.innerHTML = `
             <div class="modal-header">
-                <img src="${project.image}" alt="${project.title}" class="modal-hero-image" onerror="this.src='assets/images/python-background.jpg'">
-                <h2>${project.title}</h2>
+                <img src="${image}" alt="${title}" class="modal-hero-image" onerror="this.src='assets/images/python-background.jpg'">
+                <h2>${title}</h2>
                 <div class="modal-meta">
                     <span><i class="fas fa-star"></i> ${project.stars} Stars</span>
                     <span><i class="fas fa-code-branch"></i> ${project.forks} Forks</span>
@@ -260,7 +278,7 @@ class ProjectManager {
                 </div>
             </div>
             <div class="modal-footer">
-                <a href="${project.url}" target="_blank" class="btn btn-primary">
+                <a href="${url}" target="_blank" class="btn btn-primary">
                     <i class="fab fa-github"></i> View Repository
                 </a>
             </div>
@@ -315,7 +333,7 @@ class ProjectManager {
     }
 
     formatInline(text) {
-        return text.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+        return this.escapeHTML(text).replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
     }
 
     animateCards() {

--- a/js/projects.js
+++ b/js/projects.js
@@ -1,0 +1,342 @@
+
+const projectsData = [
+    {
+        "id": 1161091627,
+        "name": "QuickHubPulse",
+        "title": "Quickhubpulse",
+        "description": "A streamlined, modern dashboard for quick repository overview with detailed insights. Built with React 19, Tailwind CSS, and Vite.",
+        "stars": 1,
+        "forks": 0,
+        "url": "https://github.com/TheRealFREDP3D/quickhubpulse",
+        "image": "https://raw.githubusercontent.com/TheRealFREDP3D/quickhubpulse/master/image/Overview.png",
+        "pushed_at": "2026-06-04T09:56:40Z",
+        "tags": [
+            "dashboard",
+            "github",
+            "repository",
+            "stats"
+        ],
+        "narrative": "### The Vision\nQuickHubPulse was born from the need for a faster, more intuitive way to monitor GitHub repository health. While GitHub provides extensive data, navigating multiple tabs to see traffic, stars, and issues can be cumbersome. I wanted a \"pulse\" view that combined visual trends with deep insights.\n\n### The Evolution\nThe development journey focused on making the application professional and production-ready. Early commits show the core implementation using React 19 and Tailwind CSS 4. As the project matured, I shifted focus to robust state management, implementing persistent authentication via sessionStorage and refining the OAuth flow to be fully standards-compliant. The move to Node.js 20 and optimized Netlify builds ensured the dashboard stays as fast as the data it displays.\n\n### Key Features\n- **Real-time Visualization**: Using Recharts to transform raw GitHub API data into actionable traffic trends.\n- **Modern Stack**: Built with the latest React 19 features for maximum performance.\n- **Architecture**: A clean, modular design that separates the data fetching layer from the UI, as documented in the core system architecture.\n"
+    },
+    {
+        "id": 1116828897,
+        "name": "Buzz-Bites",
+        "title": "Buzz Bites",
+        "description": "A lane defense game",
+        "stars": 0,
+        "forks": 0,
+        "url": "https://github.com/TheRealFREDP3D/Buzz-Bites",
+        "image": "assets/images/python-background.jpg",
+        "pushed_at": "2026-06-01T18:14:06Z",
+        "tags": ["Game", "Python", "RTS"],
+        "narrative": "### The Vision\nBackyard Battle (Buzz vs Bite) is a passion project exploring real-time strategy (RTS) mechanics in a web environment. The goal was to create a complex simulation of colony warfare between bees and ants that runs smoothly in the browser.\n\n### The Evolution\nThe git history reveals a transition from simple unit movement to a comprehensive game loop. A major milestone was the implementation of multi-level progression and difficulty scaling, allowing the game to challenge players as they progress. I spent significant time refactoring the game state management to ensure that hundreds of active units don't compromise performance. The \"ImgBot\" integrations also highlight a commitment to optimizing assets for web delivery.\n\n### Key Features\n- **Spatial Grid Optimization**: Efficient collision and target detection for high unit counts.\n- **Adaptive AI**: An ant opponent that scales its aggression based on the player's progress.\n- **Resource Economy**: A dual-resource system (Nectar/Pollen) that forces strategic decision-making.\n"
+    },
+    {
+        "id": 1175833725,
+        "name": "fish-sim-reboot",
+        "title": "Fish Sim Reboot",
+        "description": "A sophisticated underwater ecosystem simulation featuring neural network-driven fish, dynamic plant growth, and real-time brain visualization. This project creates a living underwater world where fish evolve, plants grow, and ecological interactions emerge naturally.",
+        "stars": 1,
+        "forks": 0,
+        "url": "https://github.com/TheRealFREDP3D/fish-sim-reboot",
+        "image": "assets/images/python-background.jpg",
+        "pushed_at": "2026-05-28T21:03:09Z",
+        "tags": [
+            "brain",
+            "fish",
+            "neural-network",
+            "simulation"
+        ],
+        "narrative": "### The Vision\nThis project is a deep dive into neuroevolution. I wanted to build a world where \"intelligence\" isn't programmed, but emerges from the need to survive. Every fish in the sim is controlled by its own neural network, evolving over generations to find food and avoid predators.\n\n### The Evolution\nRecent development has been heavily focused on the \"Brain Visualizer.\" I moved away from static charts to an \"organic brain visualizer\" with bioluminescent themes and behavioral insights. This allows the user to see exactly which neurons are firing when a fish decides to turn or eat. Technical refactors also corrected thrust normalization in the NeuralFish model, leading to more realistic movement patterns.\n\n### Key Features\n- **Neural Evolution**: A custom-built neuroevolution engine where fish pass their \"brain\" weights to offspring.\n- **Living Ecosystem**: A dynamic world with day/night cycles, seasonal changes, and plant growth that responds to soil nutrients.\n- **Bioluminescent UI**: A high-performance Pygame interface that visualizes the invisible world of neural computation.\n"
+    },
+    {
+        "id": 1102381089,
+        "name": "HTB-MCP-Client",
+        "title": "Htb Mcp Client",
+        "description": "LLM-less Full-featured Textual-based TUI client for the HackTheBox MCP server",
+        "stars": 2,
+        "forks": 0,
+        "url": "https://github.com/TheRealFREDP3D/HTB-MCP-Client",
+        "image": "https://raw.githubusercontent.com/TheRealFREDP3D/HTB-MCP-Client/main/HTB-MCP-Client-Banner.png",
+        "pushed_at": "2026-05-23T14:06:42Z",
+        "tags": [
+            "client",
+            "ctf",
+            "ctf-events",
+            "ctf-tools",
+            "hackthebox",
+            "htb",
+            "htb-mcp",
+            "mcp",
+            "mcp-client",
+            "python"
+        ],
+        "narrative": "### The Vision\nHackTheBox (HTB) is a premier platform for cybersecurity training. I created this TUI (Terminal User Interface) client to streamline the experience of managing challenges and interacting with the HTB Model Context Protocol (MCP) server directly from the command line.\n\n### The Evolution\nThe project started as a tool for quick challenge lookups. It evolved into a robust management suite. Commits show a shift towards modular architecture, specifically in how schema templates are generated for the MCP. I also focused heavily on error handling and stability, replacing silent exceptions with structured logging to make the tool reliable for active CTF competitions.\n\n### Key Features\n- **Textual TUI**: A beautiful and responsive terminal interface built with Python.\n- **Container Management**: Integrated controls to start/stop challenge instances via the HTB API.\n- **Persistent State**: Automated session management so you can pick up exactly where you left off.\n"
+    },
+    {
+        "id": 1116543196,
+        "name": "PullRequest-Mermaid-Extractor",
+        "title": "Pullrequest Mermaid Extractor",
+        "description": "A developer tool to extract, view, and export Mermaid diagrams from GitHub Pull Requests conversations.",
+        "stars": 1,
+        "forks": 0,
+        "url": "https://github.com/TheRealFREDP3D/PullRequest-Mermaid-Extractor",
+        "image": "assets/images/python-background.jpg",
+        "pushed_at": "2026-05-11T01:12:14Z",
+        "tags": [
+            "developer-tools",
+            "diagram",
+            "github",
+            "mermaid",
+            "pull-request"
+        ],
+        "narrative": "### The Vision\nArchitecture documentation often lives in GitHub Pull Requests but gets buried once the PR is merged. This tool was built to surface those Mermaid diagrams, making it easy to discover and visualize the structural changes proposed in any repository.\n\n### The Evolution\nStarting as a prototype, the project quickly moved toward v0.1.1. The development focus was on the reliability of the \"MermaidRenderer\" component. I iterated on how the extractor identifies diagrams within PR comments and descriptions, ensuring that even complex nested diagrams are captured correctly. Recent maintenance focused on keeping the dependencies like picomatch and rollup updated for security and performance.\n\n### Key Features\n- **Automated Extraction**: Scans PR history to find and render Mermaid diagrams.\n- **Multiple Export Formats**: Export discovered diagrams to Markdown or Draw.io XML.\n- **Developer-Centric**: Built with React 19 and TypeScript for a type-safe, modern experience.\n"
+    },
+    {
+        "id": 891248393,
+        "name": "Ollama-Colab",
+        "title": "Ollama Colab",
+        "description": "Run Ollama on Google Colab with a public HTTPS endpoint via Cloudflare Tunnel or ngrok.",
+        "stars": 9,
+        "forks": 7,
+        "url": "https://github.com/TheRealFREDP3D/Ollama-Colab",
+        "image": "https://raw.githubusercontent.com/TheRealFREDP3D/Ollama-Colab/main/assets/header.jpg",
+        "pushed_at": "2026-05-09T19:46:39Z",
+        "tags": [
+            "ai",
+            "cloudflare",
+            "coding-assistants",
+            "colab",
+            "free-llm",
+            "llm",
+            "ngrok",
+            "ollama",
+            "tunnel"
+        ],
+        "narrative": "### The Vision\nLocal LLMs are powerful but require significant hardware. Ollama Colab bridges this gap, allowing anyone to run state-of-the-art models like Llama 3 or DeepSeek-R1 on Google's free GPU tier with zero local setup.\n\n### The Evolution\nThe project has seen rapid iterations to keep up with the fast-moving LLM landscape. V2.4 introduced multi-tunnel support (Cloudflare and ngrok), giving users more options for connectivity. The recent v2.5 release focused on optimizing the workflow for DeepSeek-R1, adding a live model browser that lets users pull and switch models without restarting the notebook.\n\n### Key Features\n- **One-Click Deployment**: Optimized Colab notebook for the fastest possible startup time.\n- **Secure Access**: Integration with Cloudflare Tunnels for stable, HTTPS-encrypted access to the Ollama API.\n- **Hardware Monitoring**: Built-in VRAM and system usage tracking to help users manage their Colab resources.\n"
+    }
+];
+
+class ProjectManager {
+    constructor() {
+        this.projects = projectsData;
+        this.filteredProjects = [...this.projects];
+        this.currentFilter = 'all';
+        this.searchQuery = '';
+
+        this.init();
+    }
+
+    init() {
+        this.renderProjects();
+        this.setupEventListeners();
+        this.updateStats();
+    }
+
+    renderProjects() {
+        const container = document.getElementById('projects-grid');
+        if (!container) return;
+
+        if (this.filteredProjects.length === 0) {
+            container.innerHTML = `
+                <div class="empty-state">
+                    <i class="fas fa-search"></i>
+                    <h3>No projects found</h3>
+                    <p>Try adjusting your search or filters.</p>
+                </div>
+            `;
+            return;
+        }
+
+        container.innerHTML = this.filteredProjects.map(project => this.createProjectCard(project)).join('');
+        this.animateCards();
+    }
+
+    createProjectCard(project) {
+        const tags = project.tags.map(tag => `<span class="tag-badge">${tag}</span>`).join('');
+
+        return `
+            <div class="project-card" data-id="${project.id}">
+                <div class="project-image">
+                    <img src="${project.image}" alt="${project.title}" onerror="this.src='assets/images/python-background.jpg'">
+                    <div class="project-stats-overlay">
+                        <span><i class="fas fa-star"></i> ${project.stars}</span>
+                        <span><i class="fas fa-code-branch"></i> ${project.forks}</span>
+                    </div>
+                </div>
+                <div class="project-content">
+                    <h3 class="project-title">${project.title}</h3>
+                    <p class="project-description">${project.description}</p>
+                    <div class="project-tags">
+                        ${tags}
+                    </div>
+                    <div class="project-footer">
+                        <button class="btn btn-primary view-details" data-id="${project.id}">View Details</button>
+                        <a href="${project.url}" target="_blank" class="github-link"><i class="fab fa-github"></i></a>
+                    </div>
+                </div>
+            </div>
+        `;
+    }
+
+    setupEventListeners() {
+        const searchInput = document.getElementById('search-projects');
+        if (searchInput) {
+            searchInput.addEventListener('input', (e) => {
+                this.searchQuery = e.target.value.toLowerCase();
+                this.applyFilters();
+            });
+        }
+
+        document.querySelectorAll('.tag-filter').forEach(btn => {
+            btn.addEventListener('click', (e) => {
+                this.currentFilter = e.target.dataset.tag;
+                document.querySelectorAll('.tag-filter').forEach(b => b.classList.remove('active'));
+                e.target.classList.add('active');
+                this.applyFilters();
+            });
+        });
+
+        // Modal triggers
+        document.addEventListener('click', (e) => {
+            if (e.target.classList.contains('view-details')) {
+                const id = e.target.dataset.id;
+                this.openModal(id);
+            }
+        });
+
+        const modal = document.getElementById('project-modal');
+        if (modal) {
+            window.addEventListener('click', (event) => {
+                if (event.target == modal) {
+                    modal.style.display = 'none';
+                    document.body.style.overflow = 'auto';
+                }
+            });
+
+            // ESC key to close
+            window.addEventListener('keydown', (e) => {
+                if (e.key === 'Escape' && modal.style.display === 'block') {
+                    modal.style.display = 'none';
+                    document.body.style.overflow = 'auto';
+                }
+            });
+        }
+    }
+
+    applyFilters() {
+        this.filteredProjects = this.projects.filter(p => {
+            const searchLower = this.searchQuery.toLowerCase();
+            const matchesSearch = p.title.toLowerCase().includes(searchLower) ||
+                                 p.description.toLowerCase().includes(searchLower);
+
+            const matchesTag = this.currentFilter === 'all' ||
+                             p.tags.some(tag => tag.toLowerCase() === this.currentFilter.toLowerCase());
+            return matchesSearch && matchesTag;
+        });
+        this.renderProjects();
+    }
+
+    openModal(id) {
+        const project = this.projects.find(p => p.id == id);
+        if (!project) return;
+
+        const modal = document.getElementById('project-modal');
+        const content = document.getElementById('modal-project-content');
+
+        content.innerHTML = `
+            <div class="modal-header">
+                <img src="${project.image}" alt="${project.title}" class="modal-hero-image" onerror="this.src='assets/images/python-background.jpg'">
+                <h2>${project.title}</h2>
+                <div class="modal-meta">
+                    <span><i class="fas fa-star"></i> ${project.stars} Stars</span>
+                    <span><i class="fas fa-code-branch"></i> ${project.forks} Forks</span>
+                    <span><i class="fas fa-clock"></i> Last updated: ${new Date(project.pushed_at).toLocaleDateString()}</span>
+                </div>
+            </div>
+            <div class="modal-body">
+                <div class="narrative">
+                    ${this.formatMarkdown(project.narrative)}
+                </div>
+            </div>
+            <div class="modal-footer">
+                <a href="${project.url}" target="_blank" class="btn btn-primary">
+                    <i class="fab fa-github"></i> View Repository
+                </a>
+            </div>
+        `;
+
+        modal.style.display = 'block';
+        document.body.style.overflow = 'hidden';
+
+        const closeBtn = modal.querySelector('.close-modal');
+        if (closeBtn) {
+            closeBtn.onclick = () => {
+                modal.style.display = 'none';
+                document.body.style.overflow = 'auto';
+            };
+        }
+    }
+
+    formatMarkdown(text) {
+        const lines = text.split('\n');
+        let html = [];
+        let inList = false;
+
+        lines.forEach(line => {
+            const trimmed = line.trim();
+
+            if (trimmed.startsWith('- ')) {
+                if (!inList) {
+                    html.push('<ul>');
+                    inList = true;
+                }
+                html.push(`<li>${this.formatInline(trimmed.substring(2))}</li>`);
+            } else {
+                if (inList) {
+                    html.push('</ul>');
+                    inList = false;
+                }
+
+                if (trimmed.startsWith('### ')) {
+                    html.push(`<h3>${this.formatInline(trimmed.substring(4))}</h3>`);
+                } else if (trimmed.startsWith('## ')) {
+                    html.push(`<h2>${this.formatInline(trimmed.substring(3))}</h2>`);
+                } else if (trimmed.startsWith('# ')) {
+                    html.push(`<h1>${this.formatInline(trimmed.substring(2))}</h1>`);
+                } else if (trimmed !== '') {
+                    html.push(`<p>${this.formatInline(trimmed)}</p>`);
+                }
+            }
+        });
+
+        if (inList) html.push('</ul>');
+        return html.join('\n');
+    }
+
+    formatInline(text) {
+        return text.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+    }
+
+    animateCards() {
+        const cards = document.querySelectorAll('.project-card');
+        cards.forEach((card, i) => {
+            card.style.opacity = '0';
+            card.style.transform = 'translateY(20px)';
+            setTimeout(() => {
+                card.style.transition = 'all 0.5s ease';
+                card.style.opacity = '1';
+                card.style.transform = 'translateY(0)';
+            }, i * 100);
+        });
+    }
+
+    updateStats() {
+        const countEl = document.getElementById('project-count');
+        if (countEl) countEl.textContent = `${this.projects.length} Projects`;
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    new ProjectManager();
+});

--- a/js/projects.js
+++ b/js/projects.js
@@ -103,6 +103,7 @@ const projectsData = [
             "github",
             "repository",
             "stats",
+            "react",
             "TypeScript"
         ],
         "narrative": "### The Vision\nQuickHubPulse was born from the need for a faster, more intuitive way to monitor GitHub repository health. While GitHub provides extensive data, navigating multiple tabs to see traffic, stars, and issues can be cumbersome. I wanted a \"pulse\" view that combined visual trends with deep insights.\n\n### The Evolution\nThe development journey focused on making the application professional and production-ready. Early commits show the core implementation using React 19 and Tailwind CSS 4. As the project matured, I shifted focus to robust state management, implementing persistent authentication via sessionStorage and refining the OAuth flow to be fully standards-compliant. The move to Node.js 20 and optimized Netlify builds ensured the dashboard stays as fast as the data it displays.\n\n### Key Features\n- **Real-time Visualization**: Using Recharts to transform raw GitHub API data into actionable traffic trends.\n- **Modern Stack**: Built with the latest React 19 features for maximum performance.\n- **Architecture**: A clean, modular design that separates the data fetching layer from the UI, as documented in the core system architecture.\n"

--- a/js/projects.js
+++ b/js/projects.js
@@ -380,7 +380,7 @@ class ProjectManager {
     }
 
     openModal(id) {
-        const project = this.projects.find(p => p.id == id);
+        const project = this.projects.find(p => p.id === Number(id));
         if (!project) return;
 
         const modal = document.getElementById('project-modal');

--- a/js/projects.js
+++ b/js/projects.js
@@ -329,9 +329,9 @@ class ProjectManager {
 
         document.querySelectorAll('.tag-filter').forEach(btn => {
             btn.addEventListener('click', (e) => {
-                this.currentFilter = e.target.dataset.tag;
+                this.currentFilter = btn.dataset.tag;
                 document.querySelectorAll('.tag-filter').forEach(b => b.classList.remove('active'));
-                e.target.classList.add('active');
+                btn.classList.add('active');
                 this.applyFilters();
             });
         });
@@ -528,15 +528,22 @@ class ProjectManager {
     }
 
     animateCards() {
+        if (!this.animationTimeouts) {
+            this.animationTimeouts = [];
+        }
+        this.animationTimeouts.forEach(clearTimeout);
+        this.animationTimeouts = [];
+
         const cards = document.querySelectorAll('.project-card');
         cards.forEach((card, i) => {
             card.style.opacity = '0';
             card.style.transform = 'translateY(20px)';
-            setTimeout(() => {
+            const timeoutId = setTimeout(() => {
                 card.style.transition = 'all 0.5s ease';
                 card.style.opacity = '1';
                 card.style.transform = 'translateY(0)';
             }, i * 100);
+            this.animationTimeouts.push(timeoutId);
         });
     }
 

--- a/js/projects.js
+++ b/js/projects.js
@@ -42,7 +42,6 @@ function createSafeElement(tag, text = '', className = '', attributes = {}) {
     if (className) el.className = className;
     if (text) el.textContent = text;
 
-    // Track whether target="_blank" is being set so we can enforce rel
     let hasBlankTarget = false;
 
     for (const [key, value] of Object.entries(attributes)) {
@@ -53,12 +52,10 @@ function createSafeElement(tag, text = '', className = '', attributes = {}) {
                 el.setAttribute('target', '_blank');
                 hasBlankTarget = true;
             }
-            // Discard any other target value (e.g. _parent, _top) for safety
         } else {
-            // Only allow safe, known attributes
             const SAFE_ATTRS = new Set([
                 'alt', 'class', 'id', 'type', 'placeholder',
-                'data-id', 'data-tag', 'title', 'rel'
+                'data-id', 'data-tag', 'title', 'rel', 'aria-label'
             ]);
             if (SAFE_ATTRS.has(key)) {
                 el.setAttribute(key, value);
@@ -66,13 +63,28 @@ function createSafeElement(tag, text = '', className = '', attributes = {}) {
         }
     }
 
-    // Always enforce rel="noopener noreferrer" on blank-target links,
-    // regardless of whether the caller supplied a rel attribute.
     if (hasBlankTarget) {
         el.setAttribute('rel', 'noopener noreferrer');
     }
 
     return el;
+}
+
+/** Shared fallback image path used when a project image fails to load. */
+const FALLBACK_IMAGE = 'assets/images/python-background.jpg';
+
+/**
+ * Attaches an onerror listener to an img element that swaps in the fallback
+ * image. Keeping this in JS (rather than an inline onerror attribute) means
+ * behaviour logic stays out of markup and is easy to update in one place.
+ * @param {HTMLImageElement} img
+ */
+function attachImageFallback(img) {
+    img.addEventListener('error', () => {
+        if (img.src !== new URL(FALLBACK_IMAGE, window.location.href).href) {
+            img.src = FALLBACK_IMAGE;
+        }
+    }, { once: true });
 }
 
 const projectsData = [
@@ -91,7 +103,7 @@ const projectsData = [
             "github",
             "repository",
             "stats",
-            "React"
+            "TypeScript"
         ],
         "narrative": "### The Vision\nQuickHubPulse was born from the need for a faster, more intuitive way to monitor GitHub repository health. While GitHub provides extensive data, navigating multiple tabs to see traffic, stars, and issues can be cumbersome. I wanted a \"pulse\" view that combined visual trends with deep insights.\n\n### The Evolution\nThe development journey focused on making the application professional and production-ready. Early commits show the core implementation using React 19 and Tailwind CSS 4. As the project matured, I shifted focus to robust state management, implementing persistent authentication via sessionStorage and refining the OAuth flow to be fully standards-compliant. The move to Node.js 20 and optimized Netlify builds ensured the dashboard stays as fast as the data it displays.\n\n### Key Features\n- **Real-time Visualization**: Using Recharts to transform raw GitHub API data into actionable traffic trends.\n- **Modern Stack**: Built with the latest React 19 features for maximum performance.\n- **Architecture**: A clean, modular design that separates the data fetching layer from the UI, as documented in the core system architecture.\n"
     },
@@ -151,7 +163,7 @@ const projectsData = [
             "htb-mcp",
             "mcp",
             "mcp-client",
-            "python",
+            "Python",
             "Cybersecurity"
         ],
         "narrative": "### The Vision\nHackTheBox (HTB) is a premier platform for cybersecurity training. I created this TUI (Terminal User Interface) client to streamline the experience of managing challenges and interacting with the HTB Model Context Protocol (MCP) server directly from the command line.\n\n### The Evolution\nThe project started as a tool for quick challenge lookups. It evolved into a robust management suite. Commits show a shift towards modular architecture, specifically in how schema templates are generated for the MCP. I also focused heavily on error handling and stability, replacing silent exceptions with structured logging to make the tool reliable for active CTF competitions.\n\n### Key Features\n- **Textual TUI**: A beautiful and responsive terminal interface built with Python.\n- **Container Management**: Integrated controls to start/stop challenge instances via the HTB API.\n- **Persistent State**: Automated session management so you can pick up exactly where you left off.\n"
@@ -172,9 +184,9 @@ const projectsData = [
             "github",
             "mermaid",
             "pull-request",
-            "React"
+            "TypeScript"
         ],
-        "narrative": "### The Vision\nArchitecture documentation often lives in GitHub Pull Requests but gets buried once the PR is merged. This tool was built to surface those Mermaid diagrams, making it easy to discover and visualize the structural changes proposed in any repository.\n\n### The Evolution\nStarting as a prototype, the project quickly moved toward v0.1.1. The development focus was on the reliability of the \"MermaidRenderer\" component. I iterated on how the extractor identifies diagrams within PR comments and descriptions, ensuring that even complex nested diagrams are captured correctly. Recent maintenance focused on keeping the dependencies like picomatch and rollup updated for security and performance.\n\n### Key Features\n- **Automated Extraction**: Scans PR history to find and render Mermaid diagrams.\n- **Multiple Export Formats**: Export discovered diagrams to Markdown or Draw.io XML.\n- **Developer-Centric**: Built with React 19 and TypeScript for a type-safe, modern experience.\n"
+        "narrative": "### The Vision\nArchitecture documentation often lives in GitHub Pull Requests but gets buried once the PR is merged. This tool was built to surface those Mermaid diagrams, making it easy to discover and visualize the structural changes proposed in any repository.\n\n### The Evolution\nStarting as a prototype, the project quickly moved toward v0.1.1. The development focus was on the reliability of the \"MermaidRenderer\" component. I iterated on how the extractor identifies diagrams within PR comments and descriptions, ensuring that even complex nested diagrams are captured correctly. Recent maintenance focused on keeping the dependencies like picomatch and rollup updated for security and performance.\n\n### Key Features\n- **Automated Extraction**: Scans PR history to find and render Mermaid diagrams.\n- **Multiple Export Formats**: Export discovered diagrams to Markdown or Draw.io XML.\n- **Developer-Centric**: Built with TypeScript for a type-safe, modern experience.\n"
     },
     {
         "id": 891248393,
@@ -187,7 +199,7 @@ const projectsData = [
         "image": "https://raw.githubusercontent.com/TheRealFREDP3D/Ollama-Colab/main/assets/header.jpg",
         "pushed_at": "2025-05-09T19:46:39Z",
         "tags": [
-            "ai",
+            "AI",
             "cloudflare",
             "coding-assistants",
             "colab",
@@ -221,14 +233,15 @@ class ProjectManager {
         const container = document.getElementById('projects-grid');
         if (!container) return;
 
-        // Clear container safely
+        // Clear container safely — no innerHTML
         while (container.firstChild) {
             container.removeChild(container.firstChild);
         }
 
         if (this.filteredProjects.length === 0) {
             const emptyState = createSafeElement('div', '', 'empty-state');
-            emptyState.appendChild(createSafeElement('i', '', 'fas fa-search'));
+            const icon = createSafeElement('i', '', 'fas fa-search');
+            emptyState.appendChild(icon);
             emptyState.appendChild(createSafeElement('h3', 'No projects found'));
             emptyState.appendChild(createSafeElement('p', 'Try adjusting your search or filters.'));
             container.appendChild(emptyState);
@@ -250,10 +263,12 @@ class ProjectManager {
         // Image container
         const imageContainer = createSafeElement('div', '', 'project-image');
 
-        const img = createSafeElement('img', '', '', { alt: project.title || '' });
-        // Use setSafeUrl for image src; fall back to a safe local asset on error
+        const img = document.createElement('img');
+        img.alt = project.title || '';
+        img.className = '';
         setSafeUrl(img, 'src', project.image || '');
-        img.onerror = () => { img.setAttribute('src', 'assets/images/python-background.jpg'); };
+        // Attach fallback via JS event listener — no inline onerror attribute
+        attachImageFallback(img);
 
         const overlay = createSafeElement('div', '', 'project-stats-overlay');
 
@@ -287,7 +302,6 @@ class ProjectManager {
         const btn = createSafeElement('button', 'View Details', 'btn btn-primary view-details');
         btn.dataset.id = project.id;
 
-        // target="_blank" triggers automatic rel="noopener noreferrer" in createSafeElement
         const githubLink = createSafeElement('a', '', 'github-link', {
             href: project.url || '',
             target: '_blank'
@@ -321,7 +335,7 @@ class ProjectManager {
             });
         });
 
-        // Modal triggers
+        // Modal triggers via event delegation
         document.addEventListener('click', (e) => {
             if (e.target.classList.contains('view-details')) {
                 const id = e.target.dataset.id;
@@ -371,17 +385,20 @@ class ProjectManager {
         const content = document.getElementById('modal-project-content');
         if (!modal || !content) return;
 
-        // Clear content safely
+        // Clear content safely — no innerHTML
         while (content.firstChild) {
             content.removeChild(content.firstChild);
         }
 
-        // Header
+        // --- Header ---
         const header = createSafeElement('div', '', 'modal-header');
 
-        const img = createSafeElement('img', '', 'modal-hero-image', { alt: project.title || '' });
+        const img = document.createElement('img');
+        img.className = 'modal-hero-image';
+        img.alt = project.title || '';
         setSafeUrl(img, 'src', project.image || '');
-        img.onerror = () => { img.setAttribute('src', 'assets/images/python-background.jpg'); };
+        // Fallback via JS listener — no inline onerror attribute
+        attachImageFallback(img);
         header.appendChild(img);
 
         header.appendChild(createSafeElement('h2', project.title || 'Untitled'));
@@ -399,9 +416,7 @@ class ProjectManager {
         const updated = createSafeElement('span');
         updated.appendChild(createSafeElement('i', '', 'fas fa-clock'));
         let dateStr = 'Unknown';
-        try {
-            dateStr = new Date(project.pushed_at).toLocaleDateString();
-        } catch { /* keep default */ }
+        try { dateStr = new Date(project.pushed_at).toLocaleDateString(); } catch { /* keep default */ }
         updated.appendChild(document.createTextNode(` Last updated: ${dateStr}`));
 
         meta.appendChild(stars);
@@ -409,14 +424,14 @@ class ProjectManager {
         meta.appendChild(updated);
         header.appendChild(meta);
 
-        // Body — narrative rendered via safe DOM builder
+        // --- Body (narrative) ---
         const body = createSafeElement('div', '', 'modal-body');
         const narrativeDiv = createSafeElement('div', '', 'narrative');
-        // Guard against null/undefined narrative
+        // formatMarkdown returns a DocumentFragment — append directly, no innerHTML needed
         narrativeDiv.appendChild(this.formatMarkdown(project.narrative || ''));
         body.appendChild(narrativeDiv);
 
-        // Footer — target="_blank" triggers automatic rel="noopener noreferrer"
+        // --- Footer ---
         const footer = createSafeElement('div', '', 'modal-footer');
         const link = createSafeElement('a', '', 'btn btn-primary', {
             href: project.url || '',
@@ -435,7 +450,6 @@ class ProjectManager {
 
         const closeBtn = modal.querySelector('.close-modal');
         if (closeBtn) {
-            // Clone to remove any stale listeners before re-attaching
             const newClose = closeBtn.cloneNode(true);
             closeBtn.parentNode.replaceChild(newClose, closeBtn);
             newClose.onclick = () => {
@@ -468,7 +482,6 @@ class ProjectManager {
                 this.appendInline(li, trimmed.substring(2));
                 currentList.appendChild(li);
             } else {
-                // Any non-list line closes the current list
                 currentList = null;
 
                 if (trimmed.startsWith('### ')) {

--- a/js/projects.js
+++ b/js/projects.js
@@ -9,12 +9,13 @@ const projectsData = [
         "forks": 0,
         "url": "https://github.com/TheRealFREDP3D/quickhubpulse",
         "image": "https://raw.githubusercontent.com/TheRealFREDP3D/quickhubpulse/master/image/Overview.png",
-        "pushed_at": "2026-06-04T09:56:40Z",
+        "pushed_at": "2025-06-04T09:56:40Z",
         "tags": [
             "dashboard",
             "github",
             "repository",
-            "stats"
+            "stats",
+            "React"
         ],
         "narrative": "### The Vision\nQuickHubPulse was born from the need for a faster, more intuitive way to monitor GitHub repository health. While GitHub provides extensive data, navigating multiple tabs to see traffic, stars, and issues can be cumbersome. I wanted a \"pulse\" view that combined visual trends with deep insights.\n\n### The Evolution\nThe development journey focused on making the application professional and production-ready. Early commits show the core implementation using React 19 and Tailwind CSS 4. As the project matured, I shifted focus to robust state management, implementing persistent authentication via sessionStorage and refining the OAuth flow to be fully standards-compliant. The move to Node.js 20 and optimized Netlify builds ensured the dashboard stays as fast as the data it displays.\n\n### Key Features\n- **Real-time Visualization**: Using Recharts to transform raw GitHub API data into actionable traffic trends.\n- **Modern Stack**: Built with the latest React 19 features for maximum performance.\n- **Architecture**: A clean, modular design that separates the data fetching layer from the UI, as documented in the core system architecture.\n"
     },
@@ -27,8 +28,12 @@ const projectsData = [
         "forks": 0,
         "url": "https://github.com/TheRealFREDP3D/Buzz-Bites",
         "image": "assets/images/python-background.jpg",
-        "pushed_at": "2026-06-01T18:14:06Z",
-        "tags": ["Game", "Python", "RTS"],
+        "pushed_at": "2025-06-01T18:14:06Z",
+        "tags": [
+            "Game",
+            "Python",
+            "RTS"
+        ],
         "narrative": "### The Vision\nBackyard Battle (Buzz vs Bite) is a passion project exploring real-time strategy (RTS) mechanics in a web environment. The goal was to create a complex simulation of colony warfare between bees and ants that runs smoothly in the browser.\n\n### The Evolution\nThe git history reveals a transition from simple unit movement to a comprehensive game loop. A major milestone was the implementation of multi-level progression and difficulty scaling, allowing the game to challenge players as they progress. I spent significant time refactoring the game state management to ensure that hundreds of active units don't compromise performance. The \"ImgBot\" integrations also highlight a commitment to optimizing assets for web delivery.\n\n### Key Features\n- **Spatial Grid Optimization**: Efficient collision and target detection for high unit counts.\n- **Adaptive AI**: An ant opponent that scales its aggression based on the player's progress.\n- **Resource Economy**: A dual-resource system (Nectar/Pollen) that forces strategic decision-making.\n"
     },
     {
@@ -40,12 +45,13 @@ const projectsData = [
         "forks": 0,
         "url": "https://github.com/TheRealFREDP3D/fish-sim-reboot",
         "image": "assets/images/python-background.jpg",
-        "pushed_at": "2026-05-28T21:03:09Z",
+        "pushed_at": "2025-05-28T21:03:09Z",
         "tags": [
             "brain",
             "fish",
             "neural-network",
-            "simulation"
+            "simulation",
+            "AI"
         ],
         "narrative": "### The Vision\nThis project is a deep dive into neuroevolution. I wanted to build a world where \"intelligence\" isn't programmed, but emerges from the need to survive. Every fish in the sim is controlled by its own neural network, evolving over generations to find food and avoid predators.\n\n### The Evolution\nRecent development has been heavily focused on the \"Brain Visualizer.\" I moved away from static charts to an \"organic brain visualizer\" with bioluminescent themes and behavioral insights. This allows the user to see exactly which neurons are firing when a fish decides to turn or eat. Technical refactors also corrected thrust normalization in the NeuralFish model, leading to more realistic movement patterns.\n\n### Key Features\n- **Neural Evolution**: A custom-built neuroevolution engine where fish pass their \"brain\" weights to offspring.\n- **Living Ecosystem**: A dynamic world with day/night cycles, seasonal changes, and plant growth that responds to soil nutrients.\n- **Bioluminescent UI**: A high-performance Pygame interface that visualizes the invisible world of neural computation.\n"
     },
@@ -58,7 +64,7 @@ const projectsData = [
         "forks": 0,
         "url": "https://github.com/TheRealFREDP3D/HTB-MCP-Client",
         "image": "https://raw.githubusercontent.com/TheRealFREDP3D/HTB-MCP-Client/main/HTB-MCP-Client-Banner.png",
-        "pushed_at": "2026-05-23T14:06:42Z",
+        "pushed_at": "2025-05-23T14:06:42Z",
         "tags": [
             "client",
             "ctf",
@@ -69,7 +75,8 @@ const projectsData = [
             "htb-mcp",
             "mcp",
             "mcp-client",
-            "python"
+            "python",
+            "Cybersecurity"
         ],
         "narrative": "### The Vision\nHackTheBox (HTB) is a premier platform for cybersecurity training. I created this TUI (Terminal User Interface) client to streamline the experience of managing challenges and interacting with the HTB Model Context Protocol (MCP) server directly from the command line.\n\n### The Evolution\nThe project started as a tool for quick challenge lookups. It evolved into a robust management suite. Commits show a shift towards modular architecture, specifically in how schema templates are generated for the MCP. I also focused heavily on error handling and stability, replacing silent exceptions with structured logging to make the tool reliable for active CTF competitions.\n\n### Key Features\n- **Textual TUI**: A beautiful and responsive terminal interface built with Python.\n- **Container Management**: Integrated controls to start/stop challenge instances via the HTB API.\n- **Persistent State**: Automated session management so you can pick up exactly where you left off.\n"
     },
@@ -82,13 +89,14 @@ const projectsData = [
         "forks": 0,
         "url": "https://github.com/TheRealFREDP3D/PullRequest-Mermaid-Extractor",
         "image": "assets/images/python-background.jpg",
-        "pushed_at": "2026-05-11T01:12:14Z",
+        "pushed_at": "2025-05-11T01:12:14Z",
         "tags": [
             "developer-tools",
             "diagram",
             "github",
             "mermaid",
-            "pull-request"
+            "pull-request",
+            "React"
         ],
         "narrative": "### The Vision\nArchitecture documentation often lives in GitHub Pull Requests but gets buried once the PR is merged. This tool was built to surface those Mermaid diagrams, making it easy to discover and visualize the structural changes proposed in any repository.\n\n### The Evolution\nStarting as a prototype, the project quickly moved toward v0.1.1. The development focus was on the reliability of the \"MermaidRenderer\" component. I iterated on how the extractor identifies diagrams within PR comments and descriptions, ensuring that even complex nested diagrams are captured correctly. Recent maintenance focused on keeping the dependencies like picomatch and rollup updated for security and performance.\n\n### Key Features\n- **Automated Extraction**: Scans PR history to find and render Mermaid diagrams.\n- **Multiple Export Formats**: Export discovered diagrams to Markdown or Draw.io XML.\n- **Developer-Centric**: Built with React 19 and TypeScript for a type-safe, modern experience.\n"
     },
@@ -101,7 +109,7 @@ const projectsData = [
         "forks": 7,
         "url": "https://github.com/TheRealFREDP3D/Ollama-Colab",
         "image": "https://raw.githubusercontent.com/TheRealFREDP3D/Ollama-Colab/main/assets/header.jpg",
-        "pushed_at": "2026-05-09T19:46:39Z",
+        "pushed_at": "2025-05-09T19:46:39Z",
         "tags": [
             "ai",
             "cloudflare",
@@ -133,64 +141,124 @@ class ProjectManager {
         this.updateStats();
     }
 
-    escapeHTML(str) {
-        if (!str) return '';
-        return String(str)
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#039;');
-    }
-
     renderProjects() {
         const container = document.getElementById('projects-grid');
         if (!container) return;
 
+        // Clear container
+        while (container.firstChild) {
+            container.removeChild(container.firstChild);
+        }
+
         if (this.filteredProjects.length === 0) {
-            container.innerHTML = `
-                <div class="empty-state">
-                    <i class="fas fa-search"></i>
-                    <h3>No projects found</h3>
-                    <p>Try adjusting your search or filters.</p>
-                </div>
-            `;
+            const emptyState = document.createElement('div');
+            emptyState.className = 'empty-state';
+
+            const icon = document.createElement('i');
+            icon.className = 'fas fa-search';
+
+            const h3 = document.createElement('h3');
+            h3.textContent = 'No projects found';
+
+            const p = document.createElement('p');
+            p.textContent = 'Try adjusting your search or filters.';
+
+            emptyState.appendChild(icon);
+            emptyState.appendChild(h3);
+            emptyState.appendChild(p);
+            container.appendChild(emptyState);
             return;
         }
 
-        container.innerHTML = this.filteredProjects.map(project => this.createProjectCard(project)).join('');
+        const fragment = document.createDocumentFragment();
+        this.filteredProjects.forEach(project => {
+            fragment.appendChild(this.createProjectCard(project));
+        });
+        container.appendChild(fragment);
         this.animateCards();
     }
 
     createProjectCard(project) {
-        const tags = project.tags.map(tag => `<span class="tag-badge">${this.escapeHTML(tag)}</span>`).join('');
-        const title = this.escapeHTML(project.title);
-        const description = this.escapeHTML(project.description);
-        const image = this.escapeHTML(project.image);
-        const url = this.escapeHTML(project.url);
+        const card = document.createElement('div');
+        card.className = 'project-card';
+        card.dataset.id = project.id;
 
-        return `
-            <div class="project-card" data-id="${project.id}">
-                <div class="project-image">
-                    <img src="${image}" alt="${title}" onerror="this.src='assets/images/python-background.jpg'">
-                    <div class="project-stats-overlay">
-                        <span><i class="fas fa-star"></i> ${project.stars}</span>
-                        <span><i class="fas fa-code-branch"></i> ${project.forks}</span>
-                    </div>
-                </div>
-                <div class="project-content">
-                    <h3 class="project-title">${title}</h3>
-                    <p class="project-description">${description}</p>
-                    <div class="project-tags">
-                        ${tags}
-                    </div>
-                    <div class="project-footer">
-                        <button class="btn btn-primary view-details" data-id="${project.id}">View Details</button>
-                        <a href="${url}" target="_blank" class="github-link"><i class="fab fa-github"></i></a>
-                    </div>
-                </div>
-            </div>
-        `;
+        const imageContainer = document.createElement('div');
+        imageContainer.className = 'project-image';
+
+        const img = document.createElement('img');
+        img.src = project.image;
+        img.alt = project.title;
+        img.onerror = () => { img.src = 'assets/images/python-background.jpg'; };
+
+        const overlay = document.createElement('div');
+        overlay.className = 'project-stats-overlay';
+
+        const starSpan = document.createElement('span');
+        const starIcon = document.createElement('i');
+        starIcon.className = 'fas fa-star';
+        starSpan.appendChild(starIcon);
+        starSpan.appendChild(document.createTextNode(` ${project.stars}`));
+
+        const forkSpan = document.createElement('span');
+        const forkIcon = document.createElement('i');
+        forkIcon.className = 'fas fa-code-branch';
+        forkSpan.appendChild(forkIcon);
+        forkSpan.appendChild(document.createTextNode(` ${project.forks}`));
+
+        overlay.appendChild(starSpan);
+        overlay.appendChild(forkSpan);
+        imageContainer.appendChild(img);
+        imageContainer.appendChild(overlay);
+
+        const content = document.createElement('div');
+        content.className = 'project-content';
+
+        const h3 = document.createElement('h3');
+        h3.className = 'project-title';
+        h3.textContent = project.title;
+
+        const p = document.createElement('p');
+        p.className = 'project-description';
+        p.textContent = project.description;
+
+        const tagsContainer = document.createElement('div');
+        tagsContainer.className = 'project-tags';
+        project.tags.forEach(tag => {
+            const span = document.createElement('span');
+            span.className = 'tag-badge';
+            span.textContent = tag;
+            tagsContainer.appendChild(span);
+        });
+
+        const footer = document.createElement('div');
+        footer.className = 'project-footer';
+
+        const btn = document.createElement('button');
+        btn.className = 'btn btn-primary view-details';
+        btn.dataset.id = project.id;
+        btn.textContent = 'View Details';
+
+        const githubLink = document.createElement('a');
+        githubLink.href = project.url;
+        githubLink.target = '_blank';
+        githubLink.className = 'github-link';
+        const githubIcon = document.createElement('i');
+        githubIcon.className = 'fab fa-github';
+        githubLink.appendChild(githubIcon);
+
+        footer.appendChild(btn);
+        footer.appendChild(githubLink);
+
+        content.appendChild(h3);
+        content.appendChild(p);
+        content.appendChild(tagsContainer);
+        content.appendChild(footer);
+
+        card.appendChild(imageContainer);
+        card.appendChild(content);
+
+        return card;
     }
 
     setupEventListeners() {
@@ -258,31 +326,79 @@ class ProjectManager {
         const modal = document.getElementById('project-modal');
         const content = document.getElementById('modal-project-content');
 
-        const title = this.escapeHTML(project.title);
-        const image = this.escapeHTML(project.image);
-        const url = this.escapeHTML(project.url);
+        // Clear content
+        while (content.firstChild) {
+            content.removeChild(content.firstChild);
+        }
 
-        content.innerHTML = `
-            <div class="modal-header">
-                <img src="${image}" alt="${title}" class="modal-hero-image" onerror="this.src='assets/images/python-background.jpg'">
-                <h2>${title}</h2>
-                <div class="modal-meta">
-                    <span><i class="fas fa-star"></i> ${project.stars} Stars</span>
-                    <span><i class="fas fa-code-branch"></i> ${project.forks} Forks</span>
-                    <span><i class="fas fa-clock"></i> Last updated: ${new Date(project.pushed_at).toLocaleDateString()}</span>
-                </div>
-            </div>
-            <div class="modal-body">
-                <div class="narrative">
-                    ${this.formatMarkdown(project.narrative)}
-                </div>
-            </div>
-            <div class="modal-footer">
-                <a href="${url}" target="_blank" class="btn btn-primary">
-                    <i class="fab fa-github"></i> View Repository
-                </a>
-            </div>
-        `;
+        const header = document.createElement('div');
+        header.className = 'modal-header';
+
+        const img = document.createElement('img');
+        img.src = project.image;
+        img.alt = project.title;
+        img.className = 'modal-hero-image';
+        img.onerror = () => { img.src = 'assets/images/python-background.jpg'; };
+
+        const h2 = document.createElement('h2');
+        h2.textContent = project.title;
+
+        const meta = document.createElement('div');
+        meta.className = 'modal-meta';
+
+        const stars = document.createElement('span');
+        const starIcon = document.createElement('i');
+        starIcon.className = 'fas fa-star';
+        stars.appendChild(starIcon);
+        stars.appendChild(document.createTextNode(` ${project.stars} Stars`));
+
+        const forks = document.createElement('span');
+        const forkIcon = document.createElement('i');
+        forkIcon.className = 'fas fa-code-branch';
+        forks.appendChild(forkIcon);
+        forks.appendChild(document.createTextNode(` ${project.forks} Forks`));
+
+        const updated = document.createElement('span');
+        const clockIcon = document.createElement('i');
+        clockIcon.className = 'fas fa-clock';
+        updated.appendChild(clockIcon);
+        const dateStr = new Date(project.pushed_at).toLocaleDateString();
+        updated.appendChild(document.createTextNode(` Last updated: ${dateStr}`));
+
+        meta.appendChild(stars);
+        meta.appendChild(forks);
+        meta.appendChild(updated);
+
+        header.appendChild(img);
+        header.appendChild(h2);
+        header.appendChild(meta);
+
+        const body = document.createElement('div');
+        body.className = 'modal-body';
+
+        const narrativeDiv = document.createElement('div');
+        narrativeDiv.className = 'narrative';
+        narrativeDiv.appendChild(this.formatMarkdown(project.narrative));
+
+        body.appendChild(narrativeDiv);
+
+        const footer = document.createElement('div');
+        footer.className = 'modal-footer';
+
+        const link = document.createElement('a');
+        link.href = project.url;
+        link.target = '_blank';
+        link.className = 'btn btn-primary';
+        const githubIcon = document.createElement('i');
+        githubIcon.className = 'fab fa-github';
+        link.appendChild(githubIcon);
+        link.appendChild(document.createTextNode(' View Repository'));
+
+        footer.appendChild(link);
+
+        content.appendChild(header);
+        content.appendChild(body);
+        content.appendChild(footer);
 
         modal.style.display = 'block';
         document.body.style.overflow = 'hidden';
@@ -298,42 +414,57 @@ class ProjectManager {
 
     formatMarkdown(text) {
         const lines = text.split('\n');
-        let html = [];
-        let inList = false;
+        const fragment = document.createDocumentFragment();
+        let currentList = null;
 
         lines.forEach(line => {
             const trimmed = line.trim();
 
             if (trimmed.startsWith('- ')) {
-                if (!inList) {
-                    html.push('<ul>');
-                    inList = true;
+                if (!currentList) {
+                    currentList = document.createElement('ul');
+                    fragment.appendChild(currentList);
                 }
-                html.push(`<li>${this.formatInline(trimmed.substring(2))}</li>`);
+                const li = document.createElement('li');
+                this.appendInline(li, trimmed.substring(2));
+                currentList.appendChild(li);
             } else {
-                if (inList) {
-                    html.push('</ul>');
-                    inList = false;
-                }
+                currentList = null;
 
                 if (trimmed.startsWith('### ')) {
-                    html.push(`<h3>${this.formatInline(trimmed.substring(4))}</h3>`);
+                    const h3 = document.createElement('h3');
+                    this.appendInline(h3, trimmed.substring(4));
+                    fragment.appendChild(h3);
                 } else if (trimmed.startsWith('## ')) {
-                    html.push(`<h2>${this.formatInline(trimmed.substring(3))}</h2>`);
+                    const h2 = document.createElement('h2');
+                    this.appendInline(h2, trimmed.substring(3));
+                    fragment.appendChild(h2);
                 } else if (trimmed.startsWith('# ')) {
-                    html.push(`<h1>${this.formatInline(trimmed.substring(2))}</h1>`);
+                    const h1 = document.createElement('h1');
+                    this.appendInline(h1, trimmed.substring(2));
+                    fragment.appendChild(h1);
                 } else if (trimmed !== '') {
-                    html.push(`<p>${this.formatInline(trimmed)}</p>`);
+                    const p = document.createElement('p');
+                    this.appendInline(p, trimmed);
+                    fragment.appendChild(p);
                 }
             }
         });
 
-        if (inList) html.push('</ul>');
-        return html.join('\n');
+        return fragment;
     }
 
-    formatInline(text) {
-        return this.escapeHTML(text).replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+    appendInline(el, text) {
+        const parts = text.split(/(\*\*.+?\*\*)/g);
+        parts.forEach(part => {
+            if (part.startsWith('**') && part.endsWith('**')) {
+                const strong = document.createElement('strong');
+                strong.textContent = part.substring(2, part.length - 2);
+                el.appendChild(strong);
+            } else if (part) {
+                el.appendChild(document.createTextNode(part));
+            }
+        });
     }
 
     animateCards() {

--- a/js/projects.js
+++ b/js/projects.js
@@ -155,6 +155,7 @@ const projectsData = [
         "image": "https://raw.githubusercontent.com/TheRealFREDP3D/HTB-MCP-Client/main/HTB-MCP-Client-Banner.png",
         "pushed_at": "2025-05-23T14:06:42Z",
         "tags": [
+        "tags": [
             "client",
             "ctf",
             "ctf-events",
@@ -164,8 +165,8 @@ const projectsData = [
             "htb-mcp",
             "mcp",
             "mcp-client",
-            "Python",
-            "Cybersecurity"
+            "python",
+            "cybersecurity"
         ],
         "narrative": "### The Vision\nHackTheBox (HTB) is a premier platform for cybersecurity training. I created this TUI (Terminal User Interface) client to streamline the experience of managing challenges and interacting with the HTB Model Context Protocol (MCP) server directly from the command line.\n\n### The Evolution\nThe project started as a tool for quick challenge lookups. It evolved into a robust management suite. Commits show a shift towards modular architecture, specifically in how schema templates are generated for the MCP. I also focused heavily on error handling and stability, replacing silent exceptions with structured logging to make the tool reliable for active CTF competitions.\n\n### Key Features\n- **Textual TUI**: A beautiful and responsive terminal interface built with Python.\n- **Container Management**: Integrated controls to start/stop challenge instances via the HTB API.\n- **Persistent State**: Automated session management so you can pick up exactly where you left off.\n"
     },

--- a/projects.html
+++ b/projects.html
@@ -4,292 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Projects - THEREALFRED.CA</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/responsive.css">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <style>
-        :root {
-            --bg-color: #0a192f;
-            --accent-color: #00ff00;
-            --text-primary: #ccd6f6;
-            --text-secondary: #8892b0;
-            --card-bg: rgba(17, 34, 64, 0.7);
-        }
-
-        body {
-            background-color: var(--bg-color);
-            color: var(--text-primary);
-        }
-
-        .projects-header {
-            padding: 8rem 0 4rem;
-            text-align: center;
-            background: linear-gradient(to bottom, rgba(0, 255, 0, 0.05), transparent);
-        }
-
-        .projects-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-            gap: 2rem;
-            margin-top: 3rem;
-        }
-
-        .project-card {
-            background: var(--card-bg);
-            border-radius: 12px;
-            overflow: hidden;
-            border: 1px solid rgba(0, 255, 0, 0.1);
-            transition: all 0.3s ease;
-            display: flex;
-            flex-direction: column;
-        }
-
-        .project-card:hover {
-            transform: translateY(-10px);
-            border-color: var(--accent-color);
-            box-shadow: 0 10px 30px -15px rgba(0, 255, 0, 0.3);
-        }
-
-        .project-image {
-            height: 200px;
-            position: relative;
-            overflow: hidden;
-        }
-
-        .project-image img {
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-            opacity: 0.8;
-            transition: transform 0.5s ease;
-        }
-
-        .project-card:hover .project-image img {
-            transform: scale(1.1);
-            opacity: 1;
-        }
-
-        .project-stats-overlay {
-            position: absolute;
-            bottom: 0;
-            right: 0;
-            background: rgba(10, 25, 47, 0.8);
-            padding: 0.5rem 1rem;
-            border-top-left-radius: 12px;
-            display: flex;
-            gap: 1rem;
-            font-size: 0.8rem;
-            color: var(--accent-color);
-        }
-
-        .project-content {
-            padding: 1.5rem;
-            flex-grow: 1;
-            display: flex;
-            flex-direction: column;
-        }
-
-        .project-title {
-            color: var(--accent-color);
-            margin-bottom: 1rem;
-            font-size: 1.25rem;
-        }
-
-        .project-description {
-            color: var(--text-secondary);
-            font-size: 0.9rem;
-            line-height: 1.6;
-            margin-bottom: 1.5rem;
-        }
-
-        .project-tags {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 0.5rem;
-            margin-bottom: 1.5rem;
-        }
-
-        .tag-badge {
-            background: rgba(0, 255, 0, 0.1);
-            color: var(--accent-color);
-            padding: 0.2rem 0.8rem;
-            border-radius: 20px;
-            font-size: 0.75rem;
-            border: 1px solid rgba(0, 255, 0, 0.2);
-        }
-
-        .project-footer {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-top: auto;
-        }
-
-        .github-link {
-            color: var(--text-secondary);
-            font-size: 1.5rem;
-            transition: color 0.3s;
-        }
-
-        .github-link:hover {
-            color: var(--accent-color);
-        }
-
-        /* Search and Filter */
-        .controls-section {
-            margin-bottom: 3rem;
-        }
-
-        .search-wrapper {
-            max-width: 600px;
-            margin: 0 auto 2rem;
-            position: relative;
-        }
-
-        .search-wrapper i {
-            position: absolute;
-            left: 1.5rem;
-            top: 50%;
-            transform: translateY(-50%);
-            color: var(--text-secondary);
-        }
-
-        .search-input {
-            width: 100%;
-            background: var(--card-bg);
-            border: 1px solid rgba(0, 255, 0, 0.1);
-            padding: 1rem 1rem 1rem 3.5rem;
-            border-radius: 30px;
-            color: var(--text-primary);
-            outline: none;
-            transition: border-color 0.3s;
-        }
-
-        .search-input:focus {
-            border-color: var(--accent-color);
-        }
-
-        .filter-tags {
-            display: flex;
-            justify-content: center;
-            flex-wrap: wrap;
-            gap: 1rem;
-        }
-
-        .tag-filter {
-            background: transparent;
-            border: 1px solid rgba(0, 255, 0, 0.2);
-            color: var(--text-secondary);
-            padding: 0.5rem 1.5rem;
-            border-radius: 20px;
-            cursor: pointer;
-            transition: all 0.3s;
-        }
-
-        .tag-filter.active, .tag-filter:hover {
-            background: var(--accent-color);
-            color: var(--bg-color);
-            border-color: var(--accent-color);
-        }
-
-        /* Modal Styles */
-        .modal {
-            display: none;
-            position: fixed;
-            z-index: 1000;
-            left: 0;
-            top: 0;
-            width: 100%;
-            height: 100%;
-            background-color: rgba(10, 25, 47, 0.95);
-            backdrop-filter: blur(5px);
-            overflow-y: auto;
-        }
-
-        .modal-content {
-            background-color: var(--card-bg);
-            margin: 5% auto;
-            padding: 0;
-            border: 1px solid rgba(0, 255, 0, 0.2);
-            width: 90%;
-            max-width: 900px;
-            border-radius: 15px;
-            position: relative;
-            box-shadow: 0 20px 50px rgba(0, 0, 0, 0.5);
-        }
-
-        .close-modal {
-            position: absolute;
-            right: 20px;
-            top: 20px;
-            color: var(--text-secondary);
-            font-size: 28px;
-            font-weight: bold;
-            cursor: pointer;
-            z-index: 10;
-            transition: color 0.3s;
-        }
-
-        .close-modal:hover {
-            color: var(--accent-color);
-        }
-
-        .modal-header {
-            position: relative;
-            padding: 3rem 2rem 2rem;
-            text-align: center;
-        }
-
-        .modal-hero-image {
-            width: 100%;
-            height: 300px;
-            object-fit: cover;
-            border-radius: 10px;
-            margin-bottom: 2rem;
-            border: 1px solid rgba(0, 255, 0, 0.1);
-        }
-
-        .modal-meta {
-            display: flex;
-            justify-content: center;
-            gap: 2rem;
-            color: var(--text-secondary);
-            font-size: 0.9rem;
-            margin-top: 1rem;
-        }
-
-        .modal-body {
-            padding: 0 3rem 3rem;
-            line-height: 1.8;
-            color: var(--text-primary);
-        }
-
-        .modal-body h2, .modal-body h3 {
-            color: var(--accent-color);
-            margin: 2rem 0 1rem;
-        }
-
-        .modal-footer {
-            padding: 2rem 3rem;
-            border-top: 1px solid rgba(0, 255, 0, 0.1);
-            text-align: center;
-        }
-
-        .empty-state {
-            text-align: center;
-            grid-column: 1 / -1;
-            padding: 4rem;
-        }
-
-        .empty-state i {
-            font-size: 4rem;
-            color: var(--accent-color);
-            opacity: 0.3;
-            margin-bottom: 1rem;
-        }
-    </style>
+    <link rel="stylesheet" href="css/projects.css">
 </head>
-<body>
+<body class="projects-page">
+
+    <!-- Navigation -->
     <nav class="navbar">
         <div class="nav-container">
             <div class="nav-logo">
@@ -316,7 +41,7 @@
         <div class="container">
             <h1 class="section-title">Project Portfolio</h1>
             <p class="section-subtitle">A collection of my significant projects, ranging from AI simulations to cybersecurity tools and web applications.</p>
-            <div id="project-count" style="color: var(--accent-color); margin-top: 1rem; font-family: 'JetBrains Mono';">0 Projects</div>
+            <div id="project-count" style="color: var(--highlight-color); margin-top: 1rem; font-family: 'JetBrains Mono';">0 Projects</div>
         </div>
     </header>
 
@@ -331,14 +56,14 @@
                     <button class="tag-filter active" data-tag="all">All</button>
                     <button class="tag-filter" data-tag="AI">AI</button>
                     <button class="tag-filter" data-tag="Python">Python</button>
-                    <button class="tag-filter" data-tag="React">React</button>
+                    <button class="tag-filter" data-tag="TypeScript">TypeScript</button>
                     <button class="tag-filter" data-tag="Cybersecurity">Cybersecurity</button>
-                    <button class="tag-filter" data-tag="LLM">LLM</button>
+                    <button class="tag-filter" data-tag="Game">Game</button>
                 </div>
             </div>
 
             <div class="projects-grid" id="projects-grid">
-                <!-- Projects will be populated by JS -->
+                <!-- Projects populated by JS -->
             </div>
         </div>
     </section>
@@ -346,7 +71,7 @@
     <!-- Project Modal -->
     <div id="project-modal" class="modal">
         <div class="modal-content">
-            <span class="close-modal">&times;</span>
+            <button class="close-modal" aria-label="Close modal">&times;</button>
             <div id="modal-project-content">
                 <!-- Content populated by JS -->
             </div>

--- a/projects.html
+++ b/projects.html
@@ -296,13 +296,13 @@
                 <a href="index.html" class="logo-text">THEREALFRED.CA</a>
             </div>
             <ul class="nav-menu">
-                <li><a href="index.html" class="nav-link ">Home</a></li>
-                <li><a href="index.html#about" class="nav-link ">About</a></li>
-                <li><a href="index.html#skills" class="nav-link ">Skills</a></li>
+                <li><a href="index.html" class="nav-link">Home</a></li>
+                <li><a href="index.html#about" class="nav-link">About</a></li>
+                <li><a href="index.html#skills" class="nav-link">Skills</a></li>
                 <li><a href="projects.html" class="nav-link active">Projects</a></li>
-                <li><a href="blog-enhanced.html" class="nav-link ">Blog</a></li>
-                <li><a href="index.html#stats" class="nav-link ">Stats</a></li>
-                <li><a href="index.html#contact" class="nav-link ">Contact</a></li>
+                <li><a href="blog-enhanced.html" class="nav-link">Blog</a></li>
+                <li><a href="index.html#stats" class="nav-link">Stats</a></li>
+                <li><a href="index.html#contact" class="nav-link">Contact</a></li>
             </ul>
             <div class="hamburger">
                 <span class="bar"></span>

--- a/projects.html
+++ b/projects.html
@@ -1,0 +1,367 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Projects - THEREALFRED.CA</title>
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="css/responsive.css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <style>
+        :root {
+            --bg-color: #0a192f;
+            --accent-color: #00ff00;
+            --text-primary: #ccd6f6;
+            --text-secondary: #8892b0;
+            --card-bg: rgba(17, 34, 64, 0.7);
+        }
+
+        body {
+            background-color: var(--bg-color);
+            color: var(--text-primary);
+        }
+
+        .projects-header {
+            padding: 8rem 0 4rem;
+            text-align: center;
+            background: linear-gradient(to bottom, rgba(0, 255, 0, 0.05), transparent);
+        }
+
+        .projects-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+            gap: 2rem;
+            margin-top: 3rem;
+        }
+
+        .project-card {
+            background: var(--card-bg);
+            border-radius: 12px;
+            overflow: hidden;
+            border: 1px solid rgba(0, 255, 0, 0.1);
+            transition: all 0.3s ease;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .project-card:hover {
+            transform: translateY(-10px);
+            border-color: var(--accent-color);
+            box-shadow: 0 10px 30px -15px rgba(0, 255, 0, 0.3);
+        }
+
+        .project-image {
+            height: 200px;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .project-image img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            opacity: 0.8;
+            transition: transform 0.5s ease;
+        }
+
+        .project-card:hover .project-image img {
+            transform: scale(1.1);
+            opacity: 1;
+        }
+
+        .project-stats-overlay {
+            position: absolute;
+            bottom: 0;
+            right: 0;
+            background: rgba(10, 25, 47, 0.8);
+            padding: 0.5rem 1rem;
+            border-top-left-radius: 12px;
+            display: flex;
+            gap: 1rem;
+            font-size: 0.8rem;
+            color: var(--accent-color);
+        }
+
+        .project-content {
+            padding: 1.5rem;
+            flex-grow: 1;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .project-title {
+            color: var(--accent-color);
+            margin-bottom: 1rem;
+            font-size: 1.25rem;
+        }
+
+        .project-description {
+            color: var(--text-secondary);
+            font-size: 0.9rem;
+            line-height: 1.6;
+            margin-bottom: 1.5rem;
+        }
+
+        .project-tags {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-bottom: 1.5rem;
+        }
+
+        .tag-badge {
+            background: rgba(0, 255, 0, 0.1);
+            color: var(--accent-color);
+            padding: 0.2rem 0.8rem;
+            border-radius: 20px;
+            font-size: 0.75rem;
+            border: 1px solid rgba(0, 255, 0, 0.2);
+        }
+
+        .project-footer {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-top: auto;
+        }
+
+        .github-link {
+            color: var(--text-secondary);
+            font-size: 1.5rem;
+            transition: color 0.3s;
+        }
+
+        .github-link:hover {
+            color: var(--accent-color);
+        }
+
+        /* Search and Filter */
+        .controls-section {
+            margin-bottom: 3rem;
+        }
+
+        .search-wrapper {
+            max-width: 600px;
+            margin: 0 auto 2rem;
+            position: relative;
+        }
+
+        .search-wrapper i {
+            position: absolute;
+            left: 1.5rem;
+            top: 50%;
+            transform: translateY(-50%);
+            color: var(--text-secondary);
+        }
+
+        .search-input {
+            width: 100%;
+            background: var(--card-bg);
+            border: 1px solid rgba(0, 255, 0, 0.1);
+            padding: 1rem 1rem 1rem 3.5rem;
+            border-radius: 30px;
+            color: var(--text-primary);
+            outline: none;
+            transition: border-color 0.3s;
+        }
+
+        .search-input:focus {
+            border-color: var(--accent-color);
+        }
+
+        .filter-tags {
+            display: flex;
+            justify-content: center;
+            flex-wrap: wrap;
+            gap: 1rem;
+        }
+
+        .tag-filter {
+            background: transparent;
+            border: 1px solid rgba(0, 255, 0, 0.2);
+            color: var(--text-secondary);
+            padding: 0.5rem 1.5rem;
+            border-radius: 20px;
+            cursor: pointer;
+            transition: all 0.3s;
+        }
+
+        .tag-filter.active, .tag-filter:hover {
+            background: var(--accent-color);
+            color: var(--bg-color);
+            border-color: var(--accent-color);
+        }
+
+        /* Modal Styles */
+        .modal {
+            display: none;
+            position: fixed;
+            z-index: 1000;
+            left: 0;
+            top: 0;
+            width: 100%;
+            height: 100%;
+            background-color: rgba(10, 25, 47, 0.95);
+            backdrop-filter: blur(5px);
+            overflow-y: auto;
+        }
+
+        .modal-content {
+            background-color: var(--card-bg);
+            margin: 5% auto;
+            padding: 0;
+            border: 1px solid rgba(0, 255, 0, 0.2);
+            width: 90%;
+            max-width: 900px;
+            border-radius: 15px;
+            position: relative;
+            box-shadow: 0 20px 50px rgba(0, 0, 0, 0.5);
+        }
+
+        .close-modal {
+            position: absolute;
+            right: 20px;
+            top: 20px;
+            color: var(--text-secondary);
+            font-size: 28px;
+            font-weight: bold;
+            cursor: pointer;
+            z-index: 10;
+            transition: color 0.3s;
+        }
+
+        .close-modal:hover {
+            color: var(--accent-color);
+        }
+
+        .modal-header {
+            position: relative;
+            padding: 3rem 2rem 2rem;
+            text-align: center;
+        }
+
+        .modal-hero-image {
+            width: 100%;
+            height: 300px;
+            object-fit: cover;
+            border-radius: 10px;
+            margin-bottom: 2rem;
+            border: 1px solid rgba(0, 255, 0, 0.1);
+        }
+
+        .modal-meta {
+            display: flex;
+            justify-content: center;
+            gap: 2rem;
+            color: var(--text-secondary);
+            font-size: 0.9rem;
+            margin-top: 1rem;
+        }
+
+        .modal-body {
+            padding: 0 3rem 3rem;
+            line-height: 1.8;
+            color: var(--text-primary);
+        }
+
+        .modal-body h2, .modal-body h3 {
+            color: var(--accent-color);
+            margin: 2rem 0 1rem;
+        }
+
+        .modal-footer {
+            padding: 2rem 3rem;
+            border-top: 1px solid rgba(0, 255, 0, 0.1);
+            text-align: center;
+        }
+
+        .empty-state {
+            text-align: center;
+            grid-column: 1 / -1;
+            padding: 4rem;
+        }
+
+        .empty-state i {
+            font-size: 4rem;
+            color: var(--accent-color);
+            opacity: 0.3;
+            margin-bottom: 1rem;
+        }
+    </style>
+</head>
+<body>
+    <nav class="navbar">
+        <div class="nav-container">
+            <div class="nav-logo">
+                <a href="index.html" class="logo-text">THEREALFRED.CA</a>
+            </div>
+            <ul class="nav-menu">
+                <li><a href="index.html" class="nav-link ">Home</a></li>
+                <li><a href="index.html#about" class="nav-link ">About</a></li>
+                <li><a href="index.html#skills" class="nav-link ">Skills</a></li>
+                <li><a href="projects.html" class="nav-link active">Projects</a></li>
+                <li><a href="blog-enhanced.html" class="nav-link ">Blog</a></li>
+                <li><a href="index.html#stats" class="nav-link ">Stats</a></li>
+                <li><a href="index.html#contact" class="nav-link ">Contact</a></li>
+            </ul>
+            <div class="hamburger">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </div>
+        </div>
+    </nav>
+
+    <header class="projects-header">
+        <div class="container">
+            <h1 class="section-title">Project Portfolio</h1>
+            <p class="section-subtitle">A collection of my significant projects, ranging from AI simulations to cybersecurity tools and web applications.</p>
+            <div id="project-count" style="color: var(--accent-color); margin-top: 1rem; font-family: 'JetBrains Mono';">0 Projects</div>
+        </div>
+    </header>
+
+    <section class="section">
+        <div class="container">
+            <div class="controls-section">
+                <div class="search-wrapper">
+                    <i class="fas fa-search"></i>
+                    <input type="text" id="search-projects" class="search-input" placeholder="Search projects by name or description...">
+                </div>
+                <div class="filter-tags">
+                    <button class="tag-filter active" data-tag="all">All</button>
+                    <button class="tag-filter" data-tag="AI">AI</button>
+                    <button class="tag-filter" data-tag="Python">Python</button>
+                    <button class="tag-filter" data-tag="React">React</button>
+                    <button class="tag-filter" data-tag="Cybersecurity">Cybersecurity</button>
+                    <button class="tag-filter" data-tag="LLM">LLM</button>
+                </div>
+            </div>
+
+            <div class="projects-grid" id="projects-grid">
+                <!-- Projects will be populated by JS -->
+            </div>
+        </div>
+    </section>
+
+    <!-- Project Modal -->
+    <div id="project-modal" class="modal">
+        <div class="modal-content">
+            <span class="close-modal">&times;</span>
+            <div id="modal-project-content">
+                <!-- Content populated by JS -->
+            </div>
+        </div>
+    </div>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <p>&copy; 2026 Frederick Pellerin (TheRealFredP3D). Built with passion.</p>
+            </div>
+        </div>
+    </footer>
+
+    <script src="js/projects.js"></script>
+    <script src="js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
This PR introduces a dedicated 'Projects' section to the portfolio website. It features a responsive grid of project cards that expand into detailed, blog-style narratives when clicked. The narratives are generated from repository data, including READMEs and commit histories, providing a 'Learning in Public' context for each project. The system includes search and tag filtering, and has been fully integrated into the existing site navigation.

---
*PR created automatically by Jules for task [13187792978254550976](https://jules.google.com/task/13187792978254550976) started by @TheRealFREDP3D*

## Summary by Sourcery

Add a dedicated projects portfolio page and wire it into site navigation, featuring searchable, filterable project cards with detailed narratives displayed in a modal.

New Features:
- Introduce a standalone Projects page that showcases repositories as rich portfolio cards with images, stats, tags, and GitHub links.
- Add search and tag-based filtering controls to quickly find relevant projects within the portfolio.
- Provide a project detail modal that renders narrative content in a blog-style layout with basic markdown formatting.

Enhancements:
- Update navigation across the home and blog pages so Projects links point to the new dedicated projects page and maintain active-state styling.
- Enhance the hero section CTAs on the home page to route to the new Projects page and ensure contact links are consistent.